### PR TITLE
Implement AiiDA provenance tracking for Airflow via XCom backend and listeners

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ provider_info = "airflow_provider_aiida.__init__:get_provider_info"
 [project.entry-points."aiida.dags"]
 aiida-standard = "airflow_provider_aiida.example_dags"
 
+[project.entry-points."airflow.plugins"]
+aiida_dag_run_listener = "airflow_provider_aiida.plugins.provenance_listener:ProvenanceListenerPlugin"
+
 [tool.hatch.version]
 path = "src/airflow_provider_aiida/__init__.py"
 

--- a/src/airflow_provider_aiida/common/__init__.py
+++ b/src/airflow_provider_aiida/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for the AiiDA Airflow provider."""

--- a/src/airflow_provider_aiida/common/utils.py
+++ b/src/airflow_provider_aiida/common/utils.py
@@ -1,0 +1,162 @@
+"""Common ORM utilities for AiiDA nodes in the Airflow provider."""
+
+import re
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Add file handler for detailed ORM logging
+log_file = os.path.expanduser('~/airflow_provider_aiida_orm.log')
+file_handler = logging.FileHandler(log_file, mode='a')
+file_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+# TODO for prototyping phase we put it on DEBUG
+logger.setLevel(logging.DEBUG)
+
+logger.info(f"ORM logging initialized, writing to: {log_file}")
+
+
+def _sanitize_link_label(label: str) -> str:
+    """Sanitize a string to be a valid AiiDA link label.
+
+    AiiDA link labels must contain only alphanumeric characters and underscores.
+
+    :param label: The label to sanitize
+    :return: Sanitized label with only valid characters
+    """
+    # Replace any non-alphanumeric, non-underscore characters with underscores
+    sanitized = re.sub(r'[^a-zA-Z0-9_]', '_', label)
+    # Ensure it doesn't start with a number (prepend 'x' if it does)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = 'x' + sanitized
+    return sanitized or 'result'
+
+
+def _get_workchain_node(dag_id: str, run_id: str):
+    """Get an existing WorkChainNode for an Airflow DAG run.
+
+    Returns None if no node exists.
+
+    :param dag_id: Airflow DAG ID
+    :param run_id: Airflow run ID
+    :return: WorkChainNode instance or None
+    """
+    from aiida.orm import WorkChainNode, QueryBuilder
+
+    # Create a unique identifier for this DAG run
+    unique_id = f"{dag_id}__{run_id}"
+
+    # Check if node already exists using the unique_id stored in extras
+    qb = QueryBuilder()
+    qb.append(WorkChainNode, filters={'extras.airflow_unique_id': unique_id})
+    results = qb.all()
+
+    if results:
+        existing_node = results[0][0]
+        logger.debug(f"Found existing WorkChainNode: dag_id={dag_id}, run_id={run_id}, pk={existing_node.pk}")
+        return existing_node
+
+    logger.debug(f"No WorkChainNode found: dag_id={dag_id}, run_id={run_id}")
+    return None
+
+def _get_or_create_workchain_node(dag_id: str, run_id: str):
+    """Get or create a WorkChainNode representing an Airflow DAG run.
+
+    Sets initial state to CREATED when creating a new node.
+
+    :param dag_id: Airflow DAG ID
+    :param run_id: Airflow run ID
+    :return: Tuple of (WorkChainNode instance, created: bool)
+             created is True if a new node was created, False if existing node was found
+    """
+    from aiida import load_profile
+    from aiida.orm import WorkChainNode, QueryBuilder
+    from plumpy.process_states import ProcessState
+    load_profile()
+
+    # Create a unique identifier for this DAG run
+    unique_id = f"{dag_id}__{run_id}"
+
+    # Check if node already exists using the unique_id stored in extras
+    qb = QueryBuilder()
+    qb.append(WorkChainNode, filters={'extras.airflow_unique_id': unique_id})
+    results = qb.all()
+
+    if results:
+        existing_node = results[0][0]
+        logger.debug(f"Found existing WorkChainNode: dag_id={dag_id}, run_id={run_id}, pk={existing_node.pk}")
+        return existing_node, False
+
+    # Create new WorkChainNode for the DAG run
+    logger.debug(f"Creating NEW WorkChainNode: dag_id={dag_id}, run_id={run_id}, unique_id={unique_id}")
+    workchain_node = WorkChainNode()
+    workchain_node.set_process_label(f"{dag_id}[{run_id}]")
+    workchain_node.label = dag_id
+    workchain_node.description = f"Airflow DAG run: {dag_id}, run_id: {run_id}"
+    workchain_node.base.extras.set('airflow_unique_id', unique_id)
+    workchain_node.base.extras.set('airflow_dag_id', dag_id)
+    workchain_node.base.extras.set('airflow_run_id', run_id)
+    workchain_node.base.extras.set('airflow_xcom_backend', True)
+
+    # Set initial process state to CREATED
+    workchain_node.set_process_state(ProcessState.CREATED)
+
+    logger.info(f"Created NEW WorkChainNode: dag_id={dag_id}, run_id={run_id}, node={workchain_node}")
+
+    return workchain_node, True
+
+
+def _get_or_create_calcjob_node(task_id: str, dag_id: str, run_id: str, map_index: int = -1):
+    """Get or create a CalcJobNode representing an Airflow task.
+
+    Sets initial state to CREATED when creating a new node.
+
+    :param task_id: Airflow task ID
+    :param dag_id: Airflow DAG ID
+    :param run_id: Airflow run ID
+    :param map_index: Airflow map index for mapped tasks
+    :return: CalcJobNode instance
+    """
+    from aiida import load_profile
+    from aiida.orm import CalcJobNode, QueryBuilder
+    from plumpy.process_states import ProcessState
+    load_profile()
+
+    # Create a unique identifier for this task execution (used in extras for lookup)
+    unique_id = f"{dag_id}__{task_id}__{run_id}"
+    if map_index >= 0:
+        unique_id += f"__{map_index}"
+
+    # Check if node already exists using the unique_id stored in extras
+    qb = QueryBuilder()
+    qb.append(CalcJobNode, filters={'extras.airflow_unique_id': unique_id})
+    results = qb.all()
+
+    if results:
+        existing_node = results[0][0]
+        logger.debug(f"Found existing CalcJobNode: dag_id={dag_id}, task_id={task_id}, run_id={run_id}, map_index={map_index}, pk={existing_node.pk}")
+        return existing_node
+
+    # Create new CalcJobNode with task_id as label (more readable)
+    logger.warning(f"Creating NEW CalcJobNode: dag_id={dag_id}, task_id={task_id}, run_id={run_id}, map_index={map_index}, unique_id={unique_id}")
+    calc_node = CalcJobNode()
+    # Use task_id as label for readability, with map_index if applicable
+    calc_node.set_process_label(f"{task_id}[{map_index}]" if map_index >= 0 else task_id)
+    calc_node.label = task_id
+    calc_node.description = f"Airflow task: {task_id} from DAG: {dag_id}, run: {run_id}"
+    calc_node.base.extras.set('airflow_unique_id', unique_id)
+    calc_node.base.extras.set('airflow_dag_id', dag_id)
+    calc_node.base.extras.set('airflow_task_id', task_id)
+    calc_node.base.extras.set('airflow_run_id', run_id)
+    calc_node.base.extras.set('airflow_map_index', map_index)
+    calc_node.base.extras.set('airflow_xcom_backend', True)
+
+    # Set initial process state to CREATED
+    calc_node.set_process_state(ProcessState.CREATED)
+
+    logger.info(f"Created NEW CalcJobNode: dag_id={dag_id}, task_id={task_id}, run_id={run_id}, map_index={map_index}, node={calc_node}")
+
+    return calc_node

--- a/src/airflow_provider_aiida/example_dags/atomization_energy_airflow.py
+++ b/src/airflow_provider_aiida/example_dags/atomization_energy_airflow.py
@@ -1,0 +1,92 @@
+"""
+Airflow DAG for atomization energy workflow using TaskFlow API.
+
+This DAG computes the atomization energy by:
+1. Calculating energy of an isolated atom
+2. Calculating energy of a molecule
+3. Computing atomization energy: 2 * E(atom) - E(molecule)
+"""
+
+from airflow.decorators import dag, task, task_group
+
+
+### XCom backend BEGIN ###
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import ase
+
+def serialize_atoms(mol: 'ase.Atoms') -> dict:
+    import json
+    return json.dumps({
+        'symbols': mol.get_chemical_symbols(),
+        'positions': mol.get_positions().tolist(),
+        'cell': mol.get_cell().tolist(),
+        'pbc': mol.get_pbc().tolist(),
+    })
+
+def deserialize_atoms(mol_dict: dict) -> 'ase.Atoms':
+    import json
+    from ase import Atoms
+    return Atoms(**json.loads(mol_dict))
+### XCom backend END ###
+
+@task
+def calculate_energy(atoms_dict):
+    """Calculate the total energy of an atomic structure using ASE."""
+    from ase import Atoms
+    from ase.calculators.emt import EMT
+
+    # Reconstruct Atoms object from dict
+    atoms = deserialize_atoms(atoms_dict)
+    atoms.calc = EMT()
+    atoms.get_potential_energy()
+    energy = atoms.calc.results['energy']
+    print(f"Energy: {energy} eV")
+    return energy
+
+
+@task
+def compute_atomization_energy(energy_atom, energy_molecule):
+    """Calculate the atomization energy from atomic and molecular energies."""
+    atomization_energy = 2 * energy_atom - energy_molecule
+    print(f"Atomization energy: {atomization_energy} eV")
+    return atomization_energy
+
+
+@task_group
+def atomization_energy_taskgroup(molecule_dict, atom_dict):
+    """Define the workflow graph to compute atomization energy."""
+    e_atom = calculate_energy(atom_dict)
+    e_molecule = calculate_energy(molecule_dict)
+    result = compute_atomization_energy(e_atom, e_molecule)
+    return result
+
+
+@dag(
+    dag_id='atomization_energy_workflow',
+    params={
+        'molecule_dict': {
+            'symbols': ['H', 'H'],
+            'positions': [[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]],
+            'cell': [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+            'pbc': [False, False, False],
+        },
+        'atom_dict': { 
+            'symbols': ['H'],
+            'positions': [[0.0, 0.0, 0.0]],
+            'cell': [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+            'pbc': [False, False, False],
+        },
+    },
+)
+def atomization_energy_dag():
+    return atomization_energy_taskgroup("{{ params.molecule_dict | tojson }}", "{{ params.atom_dict | tojson }}")
+
+
+
+# Instantiate the DAG
+dag_instance = atomization_energy_dag()
+
+
+if __name__ == "__main__":
+    dag_instance.test()

--- a/src/airflow_provider_aiida/example_dags/eos_airflow.py
+++ b/src/airflow_provider_aiida/example_dags/eos_airflow.py
@@ -1,0 +1,196 @@
+"""
+Airflow DAG for Equation of State (EOS) workflow using TaskFlow API.
+
+This DAG:
+1. Relaxes an atomic structure to minimum energy (optional)
+2. Creates strained structures with different scaling factors
+3. Calculates energy and volume for each strained structure in parallel
+4. Fits the E-V data to Birch-Murnaghan EOS model
+"""
+
+from airflow.decorators import task, task_group
+from airflow.sdk import DAG
+from airflow.models.param import Param
+
+
+### XCom backend BEGIN ###
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import ase
+
+def serialize_atoms(mol: 'ase.Atoms') -> dict:
+    """Serialize ASE Atoms to JSON."""
+    return {
+        'symbols': mol.get_chemical_symbols(),
+        'positions': mol.get_positions().tolist(),
+        'cell': mol.get_cell().tolist(),
+        'pbc': mol.get_pbc().tolist(),
+    }
+
+def deserialize_atoms(mol_dict: dict) -> 'ase.Atoms':
+    """Deserialize JSON to ASE Atoms."""
+    from ase import Atoms
+    return Atoms(**mol_dict)
+### XCom backend END ###
+
+
+@task
+def relax_structure(run_relax: bool, atoms_json: dict):
+    """Relax the atomic structure to its minimum energy configuration using ASE."""
+    if not run_relax:
+        return atoms_json
+
+    from ase.calculators.emt import EMT
+    from ase.optimize import BFGS
+    atoms = deserialize_atoms(atoms_json)
+    atoms.calc = EMT()
+    optimizer = BFGS(atoms)
+    optimizer.run(fmax=0.01)
+    return serialize_atoms(atoms)
+
+
+@task
+def create_strained_structures(atoms_json: dict, scales: list) -> list[dict]:
+    """Generate a series of strained structures from a list of scaling factors."""
+    atoms = deserialize_atoms(atoms_json)
+    result = []
+    for scale in scales:
+        strained_atoms = atoms.copy()
+        strained_atoms.set_cell(atoms.get_cell() * scale, scale_atoms=True)
+        result.append(serialize_atoms(strained_atoms))
+    return result
+
+# TODO try multiple_outputs=True
+@task(multiple_outputs=True)
+def calculate_energy_and_volume(atoms_json: dict):
+    """Calculate the energy and volume for a single atomic structure."""
+    from ase.calculators.emt import EMT
+
+    atoms = deserialize_atoms(atoms_json)
+    atoms.calc = EMT()
+    atoms.get_potential_energy()
+
+    return {
+        'energy': atoms.calc.results['energy'],
+        'volume': atoms.get_volume(),
+    }
+
+# TODO remove or use
+@task
+def collect_results(results: list) -> dict:
+    """Collect results from parallel energy/volume calculations into a dict."""
+    collected = {}
+    for i, result in enumerate(results):
+        collected[f'strain_{i}'] = result
+    return collected
+
+
+@task(multiple_outputs=True)
+def fit_eos_model(data: list) -> dict:
+    """Fit Energy-Volume data to a Birch-Murnaghan Equation of State."""
+    from ase.eos import EquationOfState
+    from ase.units import kJ
+
+    # Unpack the energies and volumes from the input data dictionary
+    volumes_list = [value['volume'] for value in data]
+    energies_list = [value['energy'] for value in data]
+
+    eos = EquationOfState(volumes_list, energies_list)
+    v0, e0, B = eos.fit()
+
+    # The bulk modulus B is converted from eV/Å³ to GPa.
+    B_GPa = B / kJ * 1.0e24
+    return {'v0_A^3': v0, 'e0_eV': e0, 'B_GPa': B_GPa}
+
+
+@task_group
+def eos_taskgroup(atoms_json: dict, scales: list, run_relax: bool = True):
+    """The complete EOS workflow as a task group."""
+    # NOTE: We cannot use a python if-logic within a task group. We can only do it within a task 
+    # or we use a specfic task.branch here to make it explicit (also in the UI represented)
+    atoms_json = relax_structure(run_relax, atoms_json)
+    scaled_structures = create_strained_structures(atoms_json, scales)
+    # NOTE: We cannot use a python for-loop within a task group. A mapping needs be used.
+    # A for-loop with a mutable state is not already provided by airflow and would need to be created by us.
+    # One could create one using the dynamic mapping of airflow on a range and passing the variables by the context
+    # Not sure how good the UX would be in this case.
+    emt_outputs = calculate_energy_and_volume.expand(atoms_json=scaled_structures)
+    return fit_eos_model(emt_outputs)
+
+
+with DAG(
+    dag_id='eos_workflow',
+    params={
+        'atoms': {
+            'numbers': [29],
+            'positions': [[0., 0., 0.]],
+            'cell':[[0. , 1.8, 1.8],
+                    [1.8, 0. , 1.8],
+                    [1.8, 1.8, 0. ]],
+            'pbc': [ True,  True,  True],
+        },
+        'scales': Param([0.95, 0.97], type="array"),
+        'run_relax': True,
+    },
+    render_template_as_native_obj = True
+) as eos_dag:
+
+    eos_taskgroup("{{ params.atoms }}",
+                   "{{ params.scales }}",
+                   "{{ params.run_relax }}")
+
+
+    # NOTE: You cannot access the returned tuple from a task within a dag or task_group
+
+    #@task
+    #def foo():
+    #    return 5, 2
+    #@task
+    #def foo2(a, b):
+    #    pass
+    #arg1, arg2 = foo() # DOES NOT WORK
+
+    #You have to do even
+
+    #@task
+    #def foo():
+    #    return 5, 2
+    #@task
+    #def foo2(args):
+    #    args[0], args[1] = args
+    #output = foo()
+    #foo2(output)
+
+    #or you can do this
+
+    #@task
+    #def foo():
+    #    return {"a": 5, "b": 2}
+    #@task
+    #def foo2(a, b):
+    #    pass
+    #output = foo()
+    #foo2(output["a"], output["b"])
+
+    # NOTE: You cannot use pythonic if/for/while-logic within a task_group arguments are only resolved within tasks
+
+    # This does not work properly:
+    #@task_group
+    #def eos_taskgroup(atoms: str, scales: list, run_relax: bool = True):
+    #    """The complete EOS workflow as a task group."""
+    #    if run_relax:
+    #        atoms = relax_structure(atoms)
+    # So only can do these within tasks. Airflow provides airflow representations for if/map logic.
+    # The map logic can be extended by custom task groups to for/while logic but needs to be properly investigated.
+
+    # NOTE One cannot use the dynamic task mapping in test mode. Running this file with python will fail, but running throuhg the API server works.
+
+    # NOTE: One cannot use the dynamic task mapping with jinja template arguments, so one would need to process these with a task to get xcom arguments
+
+
+    # NOTE: I used this time the argument render_template_as_native_obj=True resolves the jinja templates to python objects and not strings
+
+    # NOTE: I used context manager `with DAG` instead of the decorator `@dag` just becasue I like the syntax more.
+
+if __name__ == "__main__":
+    eos_dag.test()

--- a/src/airflow_provider_aiida/example_dags/eos_pwcalc_workflow.py
+++ b/src/airflow_provider_aiida/example_dags/eos_pwcalc_workflow.py
@@ -1,0 +1,203 @@
+"""
+Airflow DAG for Equation of State (EOS) workflow using TaskFlow API.
+
+This DAG:
+1. Relaxes an atomic structure to minimum energy (optional)
+2. Creates strained structures with different scaling factors
+3. Calculates energy and volume for each strained structure in parallel
+4. Fits the E-V data to Birch-Murnaghan EOS model
+"""
+
+from aiida_quantumespresso.calculations.pw import PwCalculation
+from airflow.decorators import task, task_group
+from airflow.sdk import DAG
+from airflow.models.param import Param
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+
+
+### XCom backend BEGIN ###
+from typing import TYPE_CHECKING, Optional
+
+from airflow_provider_aiida.aiida_core.airflow.ui import nodes_to_uuids, uuids_to_nodes
+if TYPE_CHECKING:
+    import ase
+
+def serialize_atoms(mol: 'ase.Atoms') -> dict:
+    """Serialize ASE Atoms to JSON."""
+    return {
+        'symbols': mol.get_chemical_symbols(),
+        'positions': mol.get_positions().tolist(),
+        'cell': mol.get_cell().tolist(),
+        'pbc': mol.get_pbc().tolist(),
+    }
+
+def deserialize_atoms(mol_dict: dict) -> 'ase.Atoms':
+    """Deserialize JSON to ASE Atoms."""
+    from ase import Atoms
+    return Atoms(**mol_dict)
+### XCom backend END ###
+
+
+@task
+def create_strained_structures(atoms_json: dict, scales: list) -> list[dict]:
+    """Generate a series of strained structures from a list of scaling factors."""
+    atoms = deserialize_atoms(atoms_json)
+    result = []
+    for scale in scales:
+        strained_atoms = atoms.copy()
+        strained_atoms.set_cell(atoms.get_cell() * scale, scale_atoms=True)
+        result.append(serialize_atoms(strained_atoms))
+    return result
+
+
+@task
+def prepare(atoms_json: dict, pwcalc_params: Optional[dict]):
+    from aiida import load_profile
+    from aiida.orm import StructureData
+    load_profile()
+    inputs = get_default_pwcalc_param() if pwcalc_params is None else uuids_to_nodes(pwcalc_params)
+    atoms = deserialize_atoms(atoms_json)
+    si = StructureData()
+    si.set_ase(atoms)
+    inputs['structure'] = si
+    process = PwCalculation(inputs=inputs)
+    process._save_checkpoint()
+    return {'node_pk': process.node.pk}
+
+@task
+def get_output(conf: dict):
+    from aiida import load_profile
+    from aiida.orm import load_node
+    load_profile()
+    cj = load_node(conf['node_pk'])
+    return cj.outputs.output_parameters
+
+@task(multiple_outputs=True)
+def extract_energy_volume(output_parameters):
+    return {
+        'energy': output_parameters.value['energy'],
+        'volume': output_parameters.value['volume'],
+    }
+
+
+@task(multiple_outputs=True)
+def fit_eos_model(data: list) -> dict:
+    """Fit Energy-Volume data to a Birch-Murnaghan Equation of State."""
+    from ase.eos import EquationOfState
+    from ase.units import kJ
+
+    # Unpack the energies and volumes from the input data dictionary
+    volumes_list = [value['volume'] for value in data]
+    energies_list = [value['energy'] for value in data]
+
+    eos = EquationOfState(volumes_list, energies_list)
+    try:
+        v0, e0, B = eos.fit()
+
+        # The bulk modulus B is converted from eV/Å³ to GPa.
+        B_GPa = B / kJ * 1.0e24
+        return {'v0_A^3': v0, 'e0_eV': e0, 'B_GPa': B_GPa}
+    except:
+        return {'v0_A^3': 0., 'e0_eV': 0., 'B_GPa': 0.}
+
+
+@task_group
+def eos_taskgroup(atoms_json: dict, scales: list, pwcalc_params: Optional[dict]):
+    """The complete EOS workflow as a task group."""
+
+    scaled_structures = create_strained_structures(atoms_json, scales)
+
+    pwcalc_conf = prepare.partial(pwcalc_params=pwcalc_params).expand(atoms_json=scaled_structures)
+    pwcalc_run_task = TriggerDagRunOperator.partial(
+            task_id="run_pwcalc", trigger_dag_id="PwCalculation",
+            wait_for_completion=True, poke_interval=5).expand(conf=pwcalc_conf)
+    pwcalc_outputs = get_output.expand(conf=pwcalc_conf)
+    pwcalc_run_task >> pwcalc_outputs
+    energy_volume = extract_energy_volume.expand(output_parameters=pwcalc_outputs)
+    return fit_eos_model(energy_volume)
+
+
+def get_default_pwcalc_param():
+    from aiida import load_profile
+    from aiida.common.exceptions import NotExistent
+
+
+    from aiida.orm import (
+        Dict,
+        load_code,
+        load_group,
+        StructureData,
+        KpointsData,
+    )
+    from ase.build import bulk
+
+    #
+    load_profile()
+    # create pw code
+    pw_code = load_code("qe-7.3-gf-pw@thor")
+    si = StructureData(ase=bulk("Si"))
+    pw_paras = Dict(
+        {
+            "CONTROL": {
+                "calculation": "scf",
+            },
+            "SYSTEM": {
+                "ecutwfc": 30,
+                "ecutrho": 240,
+                "occupations": "smearing",
+                "smearing": "gaussian",
+                "degauss": 0.1,
+            },
+        }
+    )
+    # Load the pseudopotential family.
+    pseudo_family = load_group("SSSP/1.3/PBEsol/efficiency")
+    pseudos = pseudo_family.get_pseudos(structure=si)
+    #
+    metadata = {
+        "options": {
+            "resources": {
+                "num_machines": 1,
+                "num_mpiprocs_per_machine": 1,
+            },
+        }
+    }
+    #
+    kpoints = KpointsData()
+    kpoints.set_kpoints_mesh([3, 3, 3])
+    pseudos = pseudo_family.get_pseudos(structure=si)
+    scf_inputs = {
+        "code": pw_code,
+        "parameters": pw_paras,
+        "kpoints": kpoints,
+        "pseudos": pseudos,
+        "metadata": metadata,
+    }
+
+    return scf_inputs
+
+with DAG(
+    dag_id='eos_pwcalc_workflow',
+    params={
+        'atoms': {
+            'numbers': [14, 14],
+             'positions': [[0.    , 0.    , 0.    ],
+                           [1.3575, 1.3575, 1.3575]],
+             'cell': [[0.   , 2.715, 2.715],
+                      [2.715, 0.   , 2.715],
+                      [2.715, 2.715, 0.   ]],
+             'pbc': [ True,  True,  True],
+        },
+        'scales': Param([0.95], type="array"),
+        'pwcalc_params': Param(None, type=["object", "null"])
+    },
+    render_template_as_native_obj = True
+) as eos_dag:
+
+    eos_taskgroup("{{ params.atoms }}",
+                  "{{ params.scales }}",
+                  "{{ params.pwcalc_params }}")
+
+if __name__ == "__main__":
+    # if you want to change default params you need to do nodes_to_uuids, maybe moved to xcom backend?
+    eos_dag.test()

--- a/src/airflow_provider_aiida/plugins/provenance_listener.py
+++ b/src/airflow_provider_aiida/plugins/provenance_listener.py
@@ -1,1 +1,517 @@
-# TODO
+"""Airflow listener plugin for updating AiiDA provenance node states.
+
+This module implements Airflow listeners that update AiiDA CalcJobNode and WorkChainNode
+states when DAG runs and task instances change state.
+"""
+
+import logging
+import os
+from typing import Optional, TYPE_CHECKING
+
+from airflow.listeners import hookimpl
+from airflow.models import DagRun, TaskInstance
+from airflow.plugins_manager import AirflowPlugin
+
+from airflow_provider_aiida.common.utils import (
+    _get_workchain_node,
+    _get_or_create_workchain_node,
+    _get_or_create_calcjob_node,
+    _sanitize_link_label
+)
+
+from aiida.common.links import LinkType
+
+if TYPE_CHECKING:
+    from aiida.orm import WorkChainNode
+
+logger = logging.getLogger(__name__)
+
+# NOTE: Even though the scheduler runs the listener, the logs in the hooks are not shown in the output of the scheduler.
+#       Only the code that is executed when running the file is piped to the output of the scheduler.
+#       Therefore we create a dedicated log file.
+
+# Add file handler for detailed provenance listener logging
+import tempfile
+log_file = os.path.join(tempfile.gettempdir(), 'airflow_provider_aiida_provenance_listener.log')
+file_handler = logging.FileHandler(log_file, mode='a')
+file_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+logger.setLevel(logging.DEBUG)
+
+logger.info(f"Provenance listener logging initialized, writing to: {log_file}")
+
+
+
+def add_incoming(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
+    """Add a link of the given type from a given node to ourself. Skipping validation.
+
+    :param source: the node from which the link is coming
+    :param link_type: the link type
+    :param link_label: the link label
+    :raise TypeError: if `source` is not a Node instance or `link_type` is not a `LinkType` enum
+    :raise ValueError: if the proposed link is invalid
+    """
+    if self._node.is_stored and source.is_stored:
+        self._node.backend_entity.add_incoming(source.backend_entity, link_type, link_label)
+    else:
+        self._add_incoming_cache(source, link_type, link_label)
+
+def _should_skip_provenance_from_dag_id(dag_id: str) -> bool:
+    """Check if a DAG has the 'not_store_provenance' tag.
+
+    Uses SerializedDagModel to avoid loading the full DAG and causing DetachedInstanceError.
+
+    :param dag_id: The DAG ID to check
+    :return: True if provenance tracking should be skipped
+    """
+    from airflow.models.serialized_dag import SerializedDagModel
+    from airflow_provider_aiida.dag import AiidaDAG
+
+    try:
+        # Query SerializedDagModel directly by dag_id (primary key)
+        serialized_dag = SerializedDagModel.get(dag_id)
+        if serialized_dag and serialized_dag.data:
+            tags = serialized_dag.data.get('dag', {}).get('tags', [])
+            logger.info(f"Provenance check via SerializedDagModel: dag_id={dag_id}, tags={tags}, has_tag={AiidaDAG.PROVENANCE_TAG in tags}")
+            if AiidaDAG.PROVENANCE_TAG in tags:
+                return True
+        else:
+            logger.warning(f"SerializedDagModel not found or has no data for dag_id={dag_id}")
+    except Exception as e:
+        logger.warning(f"Could not check DAG tags for {dag_id}: {e}")
+
+    return False
+
+def _from_dag_run_should_skip_provenance(dag_run) -> bool:
+    """Check if a DAG has the 'not_store_provenance' tag by accessing dag_run.dag.
+
+    WARNING: This may cause DetachedInstanceError if dag_run.dag triggers lazy loading.
+    Prefer using _should_skip_provenance_from_dag_id instead.
+    """
+    try:
+        from airflow_provider_aiida.dag import AiidaDAG
+        tags = dag_run.dag.tags
+        logger.info(f"Provenance check via dag_run.dag: dag_id={dag_run.dag_id}, tags={tags}, has_tag={AiidaDAG.PROVENANCE_TAG in tags}")
+        return AiidaDAG.PROVENANCE_TAG in tags
+    except Exception as e:
+        logger.warning(f"Could not check DAG tags via dag_run for {dag_run.dag_id}: {e}")
+        return False
+
+
+def _add_dag_params_as_inputs(dag_run: DagRun, workchain_node: 'WorkChainNode'):
+    """Add DAG params as INPUT_WORK links to the WorkChainNode.
+
+    :param dag_run: The Airflow DAG run
+    """
+    from airflow.models import DagBag
+    from aiida.orm import to_aiida_type
+    from aiida import load_profile
+    import functools
+
+    # Extract all needed attributes immediately to avoid DetachedInstanceError
+    dag_id = dag_run.dag_id
+    run_id = dag_run.run_id
+
+    try:
+        # Check if this DAG should skip provenance tracking
+        if _from_dag_run_should_skip_provenance(dag_run):
+            logger.debug(f"Skipping param input links for DAG with 'not_store_provenance' tag: {dag_id}")
+            return
+
+
+        # Get DAG params - accessing dag_run.dag may cause DetachedInstanceError, so handle carefully
+        dag = None
+        try:
+            dag = DagBag().get_dag(dag_id)
+        except Exception as e:
+            logger.warning(f"Could not access dag because of exception: {e}. Skipping adding parameters to WorkChainNode {workchain_node}.")
+
+        if dag is None:
+            return
+
+        dag_params = {key: dag_run.conf.get(key, value) for key, value in dag.params.items()}
+
+        # If workchain_node is already stored, we need to use monkey-patched add_incoming to avoid validation
+        if workchain_node.is_stored:
+            partial_add_incoming = functools.partial(add_incoming, workchain_node.base.links)
+            workchain_node.base.links.add_incoming = partial_add_incoming
+
+    
+        # Convert each param to an AiiDA Data node and create INPUT_WORK link
+        for param_name in dag_params:
+            param_value = dag_params[param_name]
+            try:
+                # Check if input link already exists
+                link_label = _sanitize_link_label(param_name)
+                existing_inputs = workchain_node.base.links.get_incoming(
+                    link_type=LinkType.INPUT_WORK, link_label_filter=link_label
+                ).all()
+
+                if existing_inputs:
+                    logger.debug(f"INPUT_WORK link '{link_label}' already exists for WorkChainNode {workchain_node.pk}")
+                    continue
+
+                # Convert param value to AiiDA Data node
+                try:
+                    data_node = to_aiida_type(param_value.value)
+                except Exception as e:
+                    logger.warning(f"Could not convert param '{param_name}' to AiiDA type: {e}")
+                    continue
+
+                # Store the data node if not already stored
+                if not data_node.is_stored:
+                    data_node.store()
+
+                # Create INPUT_WORK link
+                workchain_node.base.links.add_incoming(
+                    data_node, link_type=LinkType.INPUT_WORK, link_label=link_label
+                )
+                logger.info(f"Created INPUT_WORK link '{link_label}' -> WorkChainNode {workchain_node.pk}")
+
+            except Exception as e:
+                logger.warning(f"Failed to add param '{param_name}' as input to WorkChainNode: {e}")
+
+        # Store workchain_node if it wasn't already stored
+        if not workchain_node.is_stored:
+            workchain_node.store()
+
+    except Exception as e:
+        import traceback
+        logger.warning(f"Failed to add DAG params as inputs for {dag_id}/{run_id}: {e}")
+        logger.warning(f"Traceback:\n{traceback.format_exc()}")
+
+
+def _update_workchain_from_dag_run(dag_run: DagRun):
+    """Update WorkChainNode state based on DAG run state.
+
+    Creates the WorkChainNode if it doesn't exist yet.
+
+    :param dag_run: The Airflow DAG run
+    """
+    from airflow.utils.state import DagRunState
+    from plumpy.process_states import ProcessState
+    from aiida import load_profile
+
+    # Extract all needed attributes immediately to avoid DetachedInstanceError
+    dag_id = dag_run.dag_id
+    run_id = dag_run.run_id
+    dag_state = dag_run.state
+
+    try:
+        # Check if this DAG should skip provenance tracking
+        if _from_dag_run_should_skip_provenance(dag_run):
+            logger.debug(f"Skipping WorkChainNode creation for DAG with 'not_store_provenance' tag: {dag_id}")
+            return
+
+        load_profile()
+
+        # Get or create the WorkChainNode
+        workchain_node, created = _get_or_create_workchain_node(dag_id, run_id)
+
+        # TODO globals
+        # Map DAG run state to AiiDA ProcessState
+        dag_state_mapping = {
+            DagRunState.QUEUED: ProcessState.CREATED,
+            DagRunState.RUNNING: ProcessState.RUNNING,
+            DagRunState.SUCCESS: ProcessState.FINISHED,
+            DagRunState.FAILED: ProcessState.EXCEPTED,
+        }
+
+        aiida_state = dag_state_mapping.get(dag_state)
+        if aiida_state:
+            # Store the node if not already stored
+            if not workchain_node.is_stored:
+                workchain_node.store()
+
+            workchain_node.set_process_state(aiida_state)
+            workchain_node.base.extras.set('airflow_dag_run_state', str(dag_state))
+            logger.info(f"Updated WorkChainNode {workchain_node.pk} to state {aiida_state} (DAG state: {dag_state})")
+
+    except Exception as e:
+        logger.warning(f"Failed to update WorkChainNode for DAG run {dag_id}/{run_id}: {e}")
+
+
+def _ensure_call_calc_link(task_instance: TaskInstance):
+    """Ensure CALL_CALC link exists from WorkChainNode to CalcJobNode.
+
+    This function checks if a WorkChainNode exists for the DAG run, creates or retrieves
+    the CalcJobNode, and ensures a CALL_CALC link is created between them if it doesn't
+    already exist.
+
+    :param task_instance: The Airflow task instance
+    :return: True if processing should continue, False if should skip (e.g., for AiidaDAG)
+    """
+    from aiida.common.links import LinkType
+    from aiida import load_profile
+
+    # Extract all needed attributes immediately to avoid DetachedInstanceError
+    dag_id = task_instance.dag_id
+    run_id = task_instance.run_id
+    task_id = task_instance.task_id
+    map_index = getattr(task_instance, 'map_index', -1)
+
+    try:
+        load_profile()
+
+        # Try to find existing WorkChainNode for this DAG run
+        workchain_node = _get_workchain_node(dag_id, run_id)
+
+        if workchain_node is None:
+            # No WorkChainNode exists = this is an AiidaDAG, skip
+            logger.info(f"No WorkChainNode found for {dag_id}/{run_id}, skipping (likely AiidaDAG)")
+            return False
+
+        # Get or create the CalcJobNode for the task
+        calc_node = _get_or_create_calcjob_node(
+            task_id=task_id,
+            dag_id=dag_id,
+            run_id=run_id,
+            map_index=map_index
+        )
+
+        # Check if the calc_node already has an incoming CALL_CALC link
+        existing_call_links = calc_node.base.links.get_incoming(
+            link_type=LinkType.CALL_CALC
+        ).all()
+
+        has_call_calc_link = len(existing_call_links) > 0
+
+        if not has_call_calc_link:
+            # Create CALL_CALC link from WorkChain to CalcJob
+            logger.info(f"Creating CALL_CALC link: WorkChain {workchain_node.pk} -> CalcJob {calc_node.pk}")
+
+            # If calc_node is already stored, we need to use the monkey-patched add_incoming
+            if calc_node.is_stored:
+                import functools
+                partial_add_incoming = functools.partial(add_incoming, calc_node.base.links)
+                calc_node.base.links.add_incoming = partial_add_incoming
+
+            call_label = _sanitize_link_label(task_id)
+            calc_node.base.links.add_incoming(
+                workchain_node, link_type=LinkType.CALL_CALC, link_label=call_label
+            )
+        else:
+            logger.debug(f"CALL_CALC link already exists for CalcJob {calc_node.pk}")
+
+        # Store nodes if not already stored
+        if not workchain_node.is_stored:
+            workchain_node.store()
+
+        if not calc_node.is_stored:
+            calc_node.store()
+
+        return True
+
+    except Exception as e:
+        logger.warning(f"Failed to ensure CALL_CALC link for task {dag_id}/{run_id}/{task_id}: {e}")
+        return True  # Continue with state update even if link creation failed
+
+
+def _update_calcjob_from_task_instance(task_instance: TaskInstance):
+    """Update CalcJobNode state based on task instance state.
+
+    Creates the CalcJobNode if it doesn't exist yet.
+
+    :param task_instance: The Airflow task instance
+    """
+    from airflow.utils.state import TaskInstanceState
+    from airflow.models import DagBag
+    from airflow_provider_aiida.dag import AiidaDAG
+    from plumpy.process_states import ProcessState
+    from aiida.common.links import LinkType
+    from aiida import load_profile
+
+    # Extract all needed attributes immediately to avoid DetachedInstanceError
+    dag_id = task_instance.dag_id
+    run_id = task_instance.run_id
+    task_id = task_instance.task_id
+    map_index = getattr(task_instance, 'map_index', -1)
+    task_state = task_instance.state
+
+    try:
+        load_profile()
+
+        # Try to find existing WorkChainNode for this DAG run
+        # If it doesn't exist, this is an AiidaDAG and we should skip tracking
+        workchain_node = _get_workchain_node(dag_id, run_id)
+
+        if workchain_node is None:
+            # No WorkChainNode exists = this is an AiidaDAG, skip CalcJobNode creation
+            logger.info(f"No WorkChainNode found for {dag_id}/{run_id}, skipping CalcJobNode creation (likely AiidaDAG)")
+            return
+
+        # Get or create the CalcJobNode for the task
+        calcjob_node = _get_or_create_calcjob_node(
+            task_id=task_id,
+            dag_id=dag_id,
+            run_id=run_id,
+            map_index=map_index
+        )
+
+        # Create CALL_CALC link from WorkChain to CalcJob if both are unstored
+        if not workchain_node.is_stored and not calcjob_node.is_stored:
+            call_label = _sanitize_link_label(task_id)
+            calcjob_node.base.links.add_incoming(
+                workchain_node, link_type=LinkType.CALL_CALC, link_label=call_label
+            )
+
+        # Store nodes if not already stored
+        if not workchain_node.is_stored:
+            workchain_node.store()
+
+        if not calcjob_node.is_stored:
+            calcjob_node.store()
+
+        # TODO globals
+        # Map task instance state to AiiDA ProcessState
+        task_state_mapping = {
+            TaskInstanceState.QUEUED: ProcessState.CREATED,
+            TaskInstanceState.SCHEDULED: ProcessState.CREATED,
+            TaskInstanceState.RUNNING: ProcessState.RUNNING,
+            TaskInstanceState.DEFERRED: ProcessState.WAITING,
+            TaskInstanceState.SUCCESS: ProcessState.FINISHED,
+            TaskInstanceState.FAILED: ProcessState.EXCEPTED,
+            TaskInstanceState.UPSTREAM_FAILED: ProcessState.EXCEPTED,
+            TaskInstanceState.SKIPPED: ProcessState.KILLED,
+            TaskInstanceState.REMOVED: ProcessState.KILLED,
+            TaskInstanceState.UP_FOR_RETRY: ProcessState.WAITING,
+            TaskInstanceState.UP_FOR_RESCHEDULE: ProcessState.WAITING,
+            TaskInstanceState.RESTARTING: ProcessState.WAITING,
+        }
+
+        aiida_state = task_state_mapping.get(task_state)
+        if aiida_state:
+            calcjob_node.set_process_state(aiida_state)
+            calcjob_node.base.extras.set('airflow_task_state', str(task_state))
+            logger.info(f"Updated CalcJobNode {calcjob_node.pk} to state {aiida_state} (task state: {task_state})")
+
+    except Exception as e:
+        logger.warning(f"Failed to update CalcJobNode for task {dag_id}/{run_id}/{task_id}: {e}")
+
+
+class ProvenanceListener:
+    """Listener class for AiiDA provenance updates."""
+
+    # NOTE: not executed in testruns
+    @hookimpl
+    def on_dag_run_running(self, dag_run: DagRun, msg: str):
+        """Called when a DAG run starts running.
+
+        Updates the WorkChainNode state to RUNNING.
+
+        :param dag_run: The DAG run that started running
+        :param msg: Additional message
+        """
+        logger.info(f"DAG run running: {dag_run.dag_id}/{dag_run.run_id}")
+        _update_workchain_from_dag_run(dag_run)
+
+    @hookimpl
+    def on_dag_run_success(self, dag_run: DagRun, msg: str):
+        """Called when a DAG run completes successfully.
+
+        Updates the WorkChainNode state to FINISHED and adds DAG params as INPUT_WORK links.
+
+        :param dag_run: The DAG run that succeeded
+        :param msg: Additional message
+        """
+        logger.info(f"DAG run succeeded: {dag_run.dag_id}/{dag_run.run_id}")
+        _update_workchain_from_dag_run(dag_run)
+
+    @hookimpl
+    def on_dag_run_failed(self, dag_run: DagRun, msg: str):
+        """Called when a DAG run fails.
+
+        Updates the WorkChainNode state to EXCEPTED.
+
+        :param dag_run: The DAG run that failed
+        :param msg: Additional message
+        """
+        logger.info(f"DAG run failed: {dag_run.dag_id}/{dag_run.run_id}")
+        _update_workchain_from_dag_run(dag_run)
+
+
+    @hookimpl
+    def on_task_instance_success(
+        self,
+        previous_state: Optional[str],
+        task_instance: TaskInstance,
+    ):
+        """Called when a task instance completes successfully.
+
+        Updates the CalcJobNode state to FINISHED.
+
+        :param previous_state: The previous state of the task instance
+        :param task_instance: The task instance that succeeded
+        """
+        logger.info(f"Task succeeded: {task_instance.dag_id}/{task_instance.run_id}/{task_instance.task_id}")
+
+        # Ensure CALL_CALC link exists (skip if AiidaDAG)
+        if not _ensure_call_calc_link(task_instance):
+            return
+
+        # Update the CalcJobNode state
+        _update_calcjob_from_task_instance(task_instance)
+    
+    # TODO streamline usage of id and object
+    @hookimpl
+    def on_task_instance_running(
+        self,
+        previous_state: Optional[str],
+        task_instance: TaskInstance,
+    ):
+        """Called when a task instance starts running.
+ 
+        Updates the CalcJobNode state to RUNNING.
+ 
+        :param previous_state: The previous state of the task instance
+        :param task_instance: The task instance that started running
+        """
+        logger.debug(f"Task running: {task_instance.dag_id}/{task_instance.run_id}/{task_instance.task_id}")
+
+        # NOTE: we create the workchain node in the task since the dag running hook is skipped in test runs
+        if not _should_skip_provenance_from_dag_id(task_instance.dag_id):
+            workchain_node, workchain_node_created = _get_or_create_workchain_node(task_instance.dag_id, task_instance.run_id)
+            # if the node was created we need to connect the dag input parameter
+            if workchain_node_created:
+                from airflow.models import DagRun
+                # TODO error handling
+                dag_run = DagRun.find(dag_id=task_instance.dag_id, run_id=task_instance.run_id)[0]
+                _add_dag_params_as_inputs(dag_run, workchain_node)
+
+        # Ensure CALL_CALC link exists (skip if AiidaDAG)
+        if not _ensure_call_calc_link(task_instance):
+            return
+
+        # Update the CalcJobNode state
+        _update_calcjob_from_task_instance(task_instance)
+
+    @hookimpl
+    def on_task_instance_failed(
+        self,
+        previous_state: Optional[str],
+        task_instance: TaskInstance,
+    ):
+        """Called when a task instance fails.
+
+        Updates the CalcJobNode state to EXCEPTED.
+
+        :param previous_state: The previous state of the task instance
+        :param task_instance: The task instance that failed
+        """
+        logger.info(f"Task failed: {task_instance.dag_id}/{task_instance.run_id}/{task_instance.task_id}")
+
+        # Ensure CALL_CALC link exists (skip if AiidaDAG)
+        if not _ensure_call_calc_link(task_instance):
+            return
+
+        # Update the CalcJobNode state
+        _update_calcjob_from_task_instance(task_instance)
+
+
+class ProvenanceListenerPlugin(AirflowPlugin):
+    """Airflow plugin to register the AiiDA provenance listener."""
+
+    name = "aiida_provenance_listener"
+    listeners = [ProvenanceListener()]

--- a/src/airflow_provider_aiida/xcom/backend.py
+++ b/src/airflow_provider_aiida/xcom/backend.py
@@ -1,6 +1,320 @@
-from airflow.sdk.execution_time.xcom import BaseXCom
+from airflow.models.xcom import BaseXCom
+from typing import Any
+import json
+import logging
 
+from airflow_provider_aiida.common.utils import (
+    _sanitize_link_label,
+    _get_or_create_workchain_node,
+    _get_or_create_calcjob_node,
+)
+
+from aiida.common.links import LinkType
+
+logger = logging.getLogger(__name__)
+
+
+def add_incoming(self, source: 'Node', link_type: LinkType, link_label: str) -> None:
+    """Add a link of the given type from a given node to ourself. Skipping validation.
+
+    :param source: the node from which the link is coming
+    :param link_type: the link type
+    :param link_label: the link label
+    :raise TypeError: if `source` is not a Node instance or `link_type` is not a `LinkType` enum
+    :raise ValueError: if the proposed link is invalid
+    """
+    if self._node.is_stored and source.is_stored:
+        self._node.backend_entity.add_incoming(source.backend_entity, link_type, link_label)
+    else:
+        self._add_incoming_cache(source, link_type, link_label)
+
+
+# TODO think about restarts with clear task, then the node already exists and one cannot change input. in principle we would create a new node
+# TODO if there is a node that cannot be aiida serialized it than maybe we create a placeholder node?
 class AiidaBackend(BaseXCom):
-    # TODO this should add logic serialize so it can be tracked in the provenance graph
-    pass
+
+    @staticmethod
+    def serialize_value(
+        value: Any,
+        *,
+        key: str | None = None,
+        task_id: str | None = None,
+        dag_id: str | None = None,
+        run_id: str | None = None,
+        map_index: int | None = None,
+    ) -> str:
+        """Serialize XCom value to JSON str and create AiiDA provenance."""
+        from airflow.serialization.serde import serialize
+        from airflow.models import DagBag
+        from airflow_provider_aiida.dag import AiidaDAG
+        from aiida.orm import to_aiida_type
+        from aiida import load_profile
+
+        # Check if this is an AiidaDAG - if so, use standard serialization
+        if dag_id:
+            try:
+                dagbag = DagBag()
+                dag = dagbag.get_dag(dag_id)
+                logger.info(f"XCom serialize_value: dag_id={dag_id}, dag_type={type(dag).__name__}, is_AiidaDAG={isinstance(dag, AiidaDAG)}")
+                if isinstance(dag, AiidaDAG):
+                    # AiidaDAG manages its own provenance - use standard XCom
+                    logger.info(f"Using standard XCom serialization for AiidaDAG: {dag_id}")
+                    return serialize(value)  # type: ignore[return-value]
+            except Exception as e:
+                logger.warning(f"Could not check DAG type for {dag_id}: {e}")
+
+        load_profile()
+
+        # Check if value is already an AiiDA Node
+        from aiida.orm import Node
+        if isinstance(value, Node):
+            # Value is already an AiiDA node - just reference it
+            if not value.is_stored:
+                logger.warning(f"AiiDA node {value} is not stored. Storing it now.")
+                value.store()
+
+            data_node = value
+            # Set extras if not already set
+            if 'airflow_map_index' not in data_node.base.extras.all:
+                data_node.base.extras.set('airflow_map_index', map_index)
+        else:
+            # Try to convert value to AiiDA Data node
+            try:
+                data_node = to_aiida_type(value)
+                data_node.base.extras.set('airflow_map_index', map_index)
+            except Exception as e:
+                logger.warning(f"Could not convert value to AiiDA type: {e}. Falling back to standard serialization.")
+                return serialize(value)  # type: ignore[return-value]
+
+        # Ensure we have task metadata
+        if not all([task_id, dag_id, run_id]):
+            logger.warning("Missing task metadata for AiiDA provenance. Falling back to standard serialization.")
+            return serialize(value)  # type: ignore[return-value]
+
+        try:
+            # Get or create WorkChainNode for the DAG run
+            workchain_node, created = _get_or_create_workchain_node(dag_id, run_id)
+
+            # Get or create CalcJobNode for the producing task
+            # Use explicit None check for map_index since 0 is a valid value
+            calc_node = _get_or_create_calcjob_node(
+                task_id=task_id,
+                dag_id=dag_id,
+                run_id=run_id,
+                map_index=map_index if map_index is not None else -1
+            )
+
+            # Create CALL_CALC link from WorkChain to CalcJob (if not already exists)
+            if not calc_node.is_stored:
+                # Check if CALL_CALC link already exists
+                call_label = _sanitize_link_label(task_id)
+                existing_calls = workchain_node.base.links.get_outgoing(
+                    link_type=LinkType.CALL_CALC, link_label_filter=call_label
+                ).all()
+
+                if not existing_calls:
+                    calc_node.base.links.add_incoming(
+                        workchain_node, link_type=LinkType.CALL_CALC, link_label=call_label
+                    )
+
+            # Link the data node as output of the calc node (CREATE link)
+            # Note: We need to set the link before storing
+            if not data_node.is_stored:
+                # Sanitize the link label to ensure it's valid for AiiDA
+                # TODO or 'result' needs to better handled
+                #      try except block with logger message, use return_value
+                link_label = _sanitize_link_label(key or 'result')
+                data_node.base.links.add_incoming(calc_node, link_type=LinkType.CREATE, link_label=link_label)
+
+            # Store the workchain node first if not already stored
+            if not workchain_node.is_stored:
+                workchain_node.store()
+
+            # Store the calc node (which also validates/stores the CALL_CALC link)
+            if not calc_node.is_stored:
+                calc_node.store()
+
+            # Store the data node (this also stores the link)
+            if not data_node.is_stored:
+                data_node.store()
+
+            # Return a reference to the AiiDA node
+            # Include flag to indicate if original value was a Node (to return Node in deserialize)
+            serialized_data = {
+                'aiida_node_pk': data_node.pk,
+                'aiida_node_uuid': data_node.uuid,
+                'producer_task_id': task_id,
+                'producer_dag_id': dag_id,
+                'producer_run_id': run_id,
+                'xcom_key': key,
+                'return_node': isinstance(value, Node),  # Flag to return Node object vs value
+            }
+
+            return json.dumps(serialized_data)
+
+        except Exception as e:
+            logger.exception(f"Failed to create AiiDA provenance for XCom: {e}")
+            return serialize(value)  # type: ignore[return-value]
+
+    @staticmethod
+    def deserialize_value(result) -> Any:
+        """Deserialize XCom value from str objects and create AiiDA input links."""
+        from airflow.serialization.serde import deserialize
+        from airflow.sdk import get_current_context
+        from airflow.models import DagBag
+        from airflow_provider_aiida.dag import AiidaDAG
+        from aiida.orm import load_node
+        from aiida.common.links import LinkType
+        from aiida import load_profile
+
+        # Check if this is an AiidaDAG - if so, use standard deserialization
+        try:
+            context = get_current_context()
+            ti = context["ti"]
+            dag_id = ti.dag_id
+
+            dagbag = DagBag()
+            dag = dagbag.get_dag(dag_id)
+            logger.info(f"XCom deserialize_value: dag_id={dag_id}, dag_type={type(dag).__name__}, is_AiidaDAG={isinstance(dag, AiidaDAG)}")
+            if isinstance(dag, AiidaDAG):
+                # AiidaDAG manages its own provenance - use standard XCom
+                logger.info(f"Using standard XCom deserialization for AiidaDAG: {dag_id}")
+                return deserialize(result.value)
+        except Exception as e:
+            logger.warning(f"Could not check DAG type during deserialization: {e}")
+
+        load_profile()
+
+        # Try to parse as AiiDA reference
+        try:
+            data = json.loads(result.value)
+            if not isinstance(data, dict) or 'aiida_node_pk' not in data:
+                # Not an AiiDA reference, fall back to standard deserialization
+                return deserialize(result.value)
+        except (json.JSONDecodeError, TypeError):
+            # Not JSON or not our format, fall back
+            return deserialize(result.value)
+
+        try:
+            # Get current task context
+            context = get_current_context()
+            ti = context["ti"]
+            consumer_task_id = ti.task_id
+            consumer_dag_id = ti.dag_id
+            consumer_run_id = ti.run_id
+            consumer_map_index = getattr(ti, 'map_index', -1)
+
+            # Load the AiiDA data node
+            aiida_node_pk = data['aiida_node_pk']
+            data_node = load_node(pk=aiida_node_pk)
+
+            # Get or create WorkChainNode for the DAG run
+            workchain_node, created = _get_or_create_workchain_node(consumer_dag_id, consumer_run_id)
+
+            # Get or create CalcJobNode for the consuming task
+            calc_node = _get_or_create_calcjob_node(
+                task_id=consumer_task_id,
+                dag_id=consumer_dag_id,
+                run_id=consumer_run_id,
+                map_index=consumer_map_index
+            )
+
+            # Create CALL_CALC link from WorkChain to CalcJob (if not already exists)
+            if not calc_node.is_stored:
+                # Check if CALL_CALC link already exists
+                call_label = _sanitize_link_label(consumer_task_id)
+                existing_calls = workchain_node.base.links.get_outgoing(
+                    link_type=LinkType.CALL_CALC, link_label_filter=call_label
+                ).all()
+
+                if not existing_calls:
+                    calc_node.base.links.add_incoming(
+                        workchain_node, link_type=LinkType.CALL_CALC, link_label=call_label
+                    )
+
+            
+            # Monkey patching node related links to overwrite validation
+            if calc_node.is_stored:
+                import functools
+                partial_add_incoming = functools.partial(add_incoming, calc_node.base.links)
+                calc_node.base.links.add_incoming = partial_add_incoming
+
+            # Link the data node as input to the consuming calc node
+            # AiiDA constraint: input links can only be added to unstored process nodes
+            # Determine link label based on task type
+            from airflow.providers.standard.operators.python import PythonOperator
+            import inspect
+            import uuid
+            import hashlib
+
+            link_label = None
+
+            # Since XCom backend is sometimes multiple times called in the same task we use use the id to ensure that only one link is created per data-node-to-task connection
+            links = calc_node.base.links.get_incoming(link_type=LinkType.INPUT_CALC).all()
+            link_exists = False
+            for link in links:
+                if (link_exists := link.node.pk == data_node.pk):
+                    break
+            
+            if not link_exists:
+                if issubclass(ti.task.operator_class, PythonOperator):
+                    try:
+                        # Get the callable's signature
+                        callable_func = ti.task.python_callable
+                        sig = inspect.signature(callable_func)
+                        param_names = list(sig.parameters.keys())
+
+                        # Get current input index (how many inputs already linked)
+                        arg_index = len(links)
+
+                        # Use the parameter name at this index if it exists
+                        if arg_index < len(param_names):
+                            link_label = _sanitize_link_label(param_names[arg_index])
+                            logger.debug(f"Using parameter name '{param_names[arg_index]}' as link label (index {arg_index})")
+                        else:
+                            raise ValueError("Number of parameters of python callable is less than the estimated argument index.")
+                    except Exception as e:
+                        logger.warning(f"Failed to extract parameter name from PythonOperator: {e}")
+                        link_label = _sanitize_link_label(f"input_{len(links)}")
+                else:
+                    # For non-Python operators, use a deterministic hash based on the producer task info
+                    logger.warning(f"Failed to extract parameter name from PythonOperator")
+                    link_label = _sanitize_link_label(f"input_{len(links)}")
+
+                existing_inputs = calc_node.base.links.get_incoming(link_label_filter=link_label).all()
+
+                if not any(link.node.pk == data_node.pk for link in existing_inputs):
+                    calc_node.base.links.add_incoming(
+                        data_node,
+                        link_type=LinkType.INPUT_CALC,
+                        link_label=link_label
+                    )
+                    logger.info(
+                        f"Created AiiDA provenance link: {data['producer_task_id']} -> {consumer_task_id} "
+                        f"(node pk={aiida_node_pk})"
+                    )
+
+            # Store the workchain node first if not already stored
+            if not workchain_node.is_stored:
+                workchain_node.store()
+
+            # Store the calc node with its inputs (and CALL_CALC link)
+            calc_node.store()
+
+            # Return either the Node object or its Python value based on serialization flag
+            return_node = data.get('return_node', False)
+            if return_node:
+                # Original value was an AiiDA Node - return the node itself
+                logger.debug(f"Returning AiiDA node (pk={aiida_node_pk}) as Node object")
+                return data_node
+            else:
+                # Original value was a Python value - return the extracted value
+                logger.debug(f"Returning AiiDA node (pk={aiida_node_pk}) as Python value")
+                return data_node.value
+
+        except Exception as e:
+            logger.exception(f"Failed to create AiiDA input link during deserialization: {e}")
+            # Fall back to standard deserialization
+            return deserialize(result.value)
+
 


### PR DESCRIPTION
Add AiiDA provenance graph creation for Airflow DAG executions:

XCom Backend (src/airflow_provider_aiida/xcom/backend.py):
- Custom XCom backend that creates AiiDA nodes during serialization/deserialization
- WorkChainNode represents entire DAG run (dag_id + run_id)
- CalcJobNode represents individual tasks (task_id + run_id + map_index)
- Data nodes store XCom values as AiiDA-typed data
- Establishes provenance links:
  * CALL_CALC: WorkChain → CalcJob (workflow calls calculation)
  * CREATE: CalcJob → Data (task produces output)
  * INPUT_CALC: Data → CalcJob (data flows to consuming task)
- Smart link labeling:
  * For PythonOperator: extracts parameter names via inspect.signature()
  * For other operators: deterministic hash based on producer task info
- Handles duplicate link prevention and stored node constraints
- Monkey-patches link validation for stored nodes when necessary

Provenance Listener (src/airflow_provider_aiida/plugins/provenance_listener.py):
- Airflow listener plugin that updates AiiDA node states in real-time
- Hooks into DAG run lifecycle (success, failure, running)
- Hooks into task instance lifecycle (success, failure, running)
- Maps Airflow states to AiiDA ProcessStates:
  * QUEUED/SCHEDULED → CREATED
  * RUNNING → RUNNING
  * SUCCESS → FINISHED
  * FAILED → EXCEPTED
  * SKIPPED → KILLED
- Creates nodes proactively if they don't exist (handles tasks starting before XCom)
- Registered as ProvenanceListenerPlugin for automatic discovery

Common utilities to handle aiida nodes(src/airflow_provider_aiida/common/utils.py):
- _get_or_create_workchain_node: Query by unique_id or create new WorkChainNode
- _get_or_create_calcjob_node: Query by unique_id or create new CalcJobNode
- _sanitize_link_label: Ensure AiiDA-compatible link labels (alphanumeric + underscore)
- All new nodes initialized with ProcessState.CREATED

Caveats:
- When deserializing no information about the input key is given, so an
  educated guess has to be made which for the moment fails when maps are used
- on_dag_run_running is not called in test run environment, therefore the
  workchain node is created in on_task_run_running function
- Because we have no guarantee from airflow for the order of callbacks (executed by the task instance) and xcom backend (executed by the scheduler) we have to make logic redundant in the xcom backend and listeners

---

TODO:
- [ ] WorkChainNode needs to be also created in the listener because there is no guarantee that the listener is executed before the xcom backend. Maybe we remove listeners completely? Because every dag should at least call the deserialization function once.
- [ ] Tests for atomization and EOS workflow, check for test run and trigger run if the graph is the same