### PR TITLE
Implement run_get_pk for running the process as test run

### DIFF
--- a/src/airflow_provider_aiida/aiida_core/engine/launch.py
+++ b/src/airflow_provider_aiida/aiida_core/engine/launch.py
@@ -1,4 +1,4 @@
-from airflow_provider_aiida.aiida_core.engine.runner import Runner
+from airflow_provider_aiida.aiida_core.engine.runner import AirflowRunner
 from aiida.engine.utils import instantiate_process, is_process_scoped, prepare_inputs
 from aiida.engine.processes.functions import FunctionProcess
 from aiida.engine.processes.process import Process
@@ -11,6 +11,10 @@ import time
 import typing as t
 
 from airflow.api.client import get_current_api_client
+
+if t.TYPE_CHECKING:
+    from aiida.engine.runners import ResultAndPk
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,13 +51,11 @@ def submit(
     if is_process_scoped() and not isinstance(Process.current(), FunctionProcess):
         raise InvalidOperation('Cannot use top-level `submit` from within another process, use `self.submit` instead')
 
-    runner = Runner.get_instance()
+    runner = AirflowRunner(broker_submit=True)
 
     assert runner.persister is not None, 'runner does not have a persister'
 
     process_inited = instantiate_process(runner, process, **inputs)
-
-
 
     # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
     # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
@@ -87,6 +89,11 @@ def submit(
 
     return node
 
+def run(process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None, **kwargs: t.Any) -> dict[str, t.Any]:
+    raise NotImplementedError()
+
+def run_get_pk(process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None, **kwargs: t.Any) -> 'ResultAndPk':
+    raise NotImplementedError()
 
 def run_get_node(
     process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None, **kwargs: t.Any
@@ -98,41 +105,15 @@ def run_get_node(
     :return: tuple of the outputs of the process and the process node
     """
     if isinstance(process, Process):
-        runner = process.runner
+        if process.runner is None:
+            process.runner = AirflowRunner(broker_submit=False)
+            runner = process.runner
+        else:
+            runner = process.runner
+            # this case is to give a proper error message for backwards usage
+            assert isinstance(runner, AirflowRunner)
+            assert not runner.broker_submit
     else:
-        runner = Runner.get_instance()
+        runner = AirflowRunner(broker_submit=False)
 
     return runner.run_get_node(process, inputs, **kwargs)
-
-
-def create(process: TYPE_RUN_PROCESS, inputs: dict[str, t.Any] | None = None, **kwargs: t.Any,
-) -> ProcessNode:
-
-    inputs = prepare_inputs(inputs, **kwargs)
-
-    # Submitting from within another process requires ``self.submit``` unless it is a work function, in which case the
-    # current process in the scope should be an instance of ``FunctionProcess``.
-    if is_process_scoped() and not isinstance(Process.current(), FunctionProcess):
-        raise InvalidOperation('Cannot use top-level `submit` from within another process, use `self.submit` instead')
-
-    runner = Runner.get_instance()
-
-    assert runner.persister is not None, 'runner does not have a persister'
-
-    process_inited = instantiate_process(runner, process, **inputs)
-
-
-
-    # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
-    # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
-    # for if `remote_folder` is present in the inputs, which means we are importing an already completed calculation.
-    if process_inited.metadata.get('dry_run', False) or 'remote_folder' in inputs:
-        _, node = run_get_node(process_inited)
-        return node
-
-    if not process_inited.metadata.store_provenance:
-        raise InvalidOperation('cannot submit a process with `store_provenance=False`')
-
-    runner.persister.save_checkpoint(process_inited)
-    process_inited.close()
-    return process_inited.node

--- a/src/airflow_provider_aiida/aiida_core/engine/runner.py
+++ b/src/airflow_provider_aiida/aiida_core/engine/runner.py
@@ -3,16 +3,22 @@
 import asyncio
 import logging
 import signal
-from typing import Optional, Any, Callable, NamedTuple, Dict, Tuple, Union, Type
+from typing import Optional, Any, Callable, Dict, Tuple, Union, Type
+
 from aiida.engine.persistence import AiiDAPersister
 from aiida.engine.transports import TransportQueue
+from aiida.engine.runners import Runner
 from aiida.engine import utils
 from aiida.plugins.utils import PluginVersionProvider
 from aiida.engine.processes.calcjobs import manager
 from aiida.orm import ProcessNode 
 from aiida.common import exceptions
 from aiida.engine.processes import Process, ProcessBuilder
+from aiida.engine.runners import Runner, ResultAndNode
+
 from plumpy.persistence import Persister
+from plumpy.events import set_event_loop_policy
+
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,11 +27,8 @@ logging.basicConfig(level=logging.DEBUG)
 
 TYPE_RUN_PROCESS = Union[Process, Type[Process], ProcessBuilder]
 
-class ResultAndNode(NamedTuple):
-    result: Dict[str, Any]
-    node: ProcessNode
 
-class Runner:
+class AirflowRunner(Runner):
     """Singleton runner that owns the TransportQueue for the triggerer process.
 
     Since each triggerer has only one event loop, we only need one Runner instance
@@ -33,47 +36,67 @@ class Runner:
     triggers running in the same triggerer.
     """
 
-    _instance: Optional['Runner'] = None
+    _persister: Optional[Persister] = None
 
-    def __new__(cls):
-        """Create or return the single Runner instance."""
-        if cls._instance is None:
-            instance = super().__new__(cls)
+    def __init__(
+        self,
+        poll_interval: Union[int, float] = 0,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        broker_submit = False,
+    ):
+        """Construct a new runner.
 
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                # No running loop - create a new one
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
+        :param poll_interval: interval in seconds between polling for status of active sub processes
+        :param loop: an asyncio event loop, if none is suppled a new one will be created
+        :param communicator: the communicator to use
+        :param broker_submit: if True, processes will be submitted to the broker, otherwise they will be scheduled here
+        :param persister: the persister to use to persist processes
 
-            from airflow.configuration import conf
-            sql_conn = conf.get('database', 'sql_alchemy_conn', fallback='NOT SET')
-            _LOGGER.debug(f"SQL connection: {sql_conn if sql_conn != 'NOT SET' else 'NOT SET'}")
-            instance._loop = loop
-            instance._poll_interval = 0
-            # NOTE: A triggerer set the sql connection variable to "airflow-db-not-allowed:///"
-            #       while in a test run this is set to a poper sql connection
-            instance._broker_submit = True #sql_conn == "airflow-db-not-allowed:///"
-            instance._transport = TransportQueue(instance._loop)
-            instance._job_manager = manager.JobManager(instance._transport)
-            instance._persister = AiiDAPersister()
-            instance._plugin_version_provider = PluginVersionProvider()
-            instance._communicator = None
-            instance._controller = None
+        """
+        set_event_loop_policy()
+        self._loop = loop if loop is not None else asyncio.get_event_loop()
+        self._poll_interval = poll_interval
+        self._transport = TransportQueue(self._loop)
+        self._job_manager = manager.JobManager(self._transport)
+        self._persister = AiiDAPersister()
+        self._plugin_version_provider = PluginVersionProvider()
 
-            cls._instance = instance
-            _LOGGER.debug(f"Runner initialized with event loop {id(loop)}")
+        self._broker_submit = broker_submit
 
-        return cls._instance
 
-    def __init__(self):
-        pass
+    def _run(
+        self, process: TYPE_RUN_PROCESS, inputs: dict[str, Any] | None = None, **kwargs: Any
+    ) -> Tuple[Dict[str, Any], ProcessNode]:
+        """Run the process with the supplied inputs in this runner that will block until the process is completed.
 
-    @classmethod
-    def get_instance(cls) -> 'Runner':
-        """Get the singleton Runner instance."""
-        return cls()
+        The return value will be the results of the completed process
+
+        :param process: the process class or process function to run
+        :param inputs: the inputs to be passed to the process
+        :return: tuple of the outputs of the process and the calculation node
+        """
+        inputs = utils.prepare_inputs(inputs, **kwargs)
+
+        if utils.is_process_function(process):
+            result, node = process.run_get_node(**inputs)  # type: ignore[union-attr]
+            return result, node
+
+        process_inited = self.instantiate_process(process, **inputs)
+
+        from airflow.models import DagBag
+        dag_id = process.__name__
+        dag = DagBag().get_dag(dag_id)
+
+        if dag is None:
+            raise ValueError(f"Could not find DAG corresponding to process class {dag_id!r}")
+
+        dag.test(
+            run_conf={
+                "node_pk": process_inited.node.pk
+            }
+        )
+        return process_inited.outputs, process_inited.node
+
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
@@ -107,12 +130,6 @@ class Runner:
         """Get the controller used by this runner."""
         return None
 
-    @classmethod
-    def clear(cls):
-        """Clear the singleton instance (useful for testing)."""
-        cls._instance = None
-        _LOGGER.debug("Cleared Runner singleton")
-
     def instantiate_process(self, process, **inputs):
         return utils.instantiate_process(self, process, **inputs)
 
@@ -126,7 +143,6 @@ class Runner:
         :return: the calculation node of the process
         """
         assert not utils.is_process_function(process), 'Cannot submit a process function'
-        #assert not self._closed
 
         inputs = utils.prepare_inputs(inputs, **kwargs)
         process_inited = self.instantiate_process(process, **inputs)
@@ -242,71 +258,3 @@ client.trigger_dag(
             self._loop.call_soon(callback)
         else:
             self._loop.call_later(self._poll_interval, self._poll_process, node, callback)
-
-    def _run(
-        self, process: TYPE_RUN_PROCESS, inputs: dict[str, Any] | None = None, **kwargs: Any
-    ) -> Tuple[Dict[str, Any], ProcessNode]:
-        """Run the process with the supplied inputs in this runner that will block until the process is completed.
-
-        The return value will be the results of the completed process
-
-        :param process: the process class or process function to run
-        :param inputs: the inputs to be passed to the process
-        :return: tuple of the outputs of the process and the calculation node
-        """
-        inputs = utils.prepare_inputs(inputs, **kwargs)
-
-        if utils.is_process_function(process):
-            result, node = process.run_get_node(**inputs)  # type: ignore[union-attr]
-            return result, node
-
-        with utils.loop_scope(self.loop):
-            process_inited = self.instantiate_process(process, **inputs)
-
-            def kill_process(_num, _frame):
-                """Send the kill signal to the process in the current scope."""
-                if process_inited.is_killing:
-                    LOGGER.warning('runner received interrupt, process %s already being killed', process_inited.pid)
-                    return
-                LOGGER.critical('runner received interrupt, killing process %s', process_inited.pid)
-                process_inited.kill(msg_text='Process was killed because the runner received an interrupt')
-
-            original_handler_int = signal.getsignal(signal.SIGINT)
-            original_handler_term = signal.getsignal(signal.SIGTERM)
-
-            try:
-                signal.signal(signal.SIGINT, kill_process)
-                signal.signal(signal.SIGTERM, kill_process)
-                process_inited.execute()
-            finally:
-                signal.signal(signal.SIGINT, original_handler_int)
-                signal.signal(signal.SIGTERM, original_handler_term)
-
-            return process_inited.outputs, process_inited.node
-
-    def run(self, process: TYPE_RUN_PROCESS, inputs: dict[str, Any] | None = None, **kwargs: Any) -> Dict[str, Any]:
-        """Run the process with the supplied inputs in this runner that will block until the process is completed.
-
-        The return value will be the results of the completed process
-
-        :param process: the process class or process function to run
-        :param inputs: the inputs to be passed to the process
-        :return: the outputs of the process
-        """
-        result, _ = self._run(process, inputs, **kwargs)
-        return result
-
-    def run_get_node(
-        self, process: TYPE_RUN_PROCESS, inputs: dict[str, Any] | None = None, **kwargs: Any
-    ) -> ResultAndNode:
-        """Run the process with the supplied inputs in this runner that will block until the process is completed.
-
-        The return value will be the results of the completed process
-
-        :param process: the process class or process function to run
-        :param inputs: the inputs to be passed to the process
-        :return: tuple of the outputs of the process and the calculation node
-        """
-        result, node = self._run(process, inputs, **kwargs)
-        return ResultAndNode(result, node)
-

--- a/src/airflow_provider_aiida/example_dags/arithmetic_add.py
+++ b/src/airflow_provider_aiida/example_dags/arithmetic_add.py
@@ -19,8 +19,7 @@ with DAG(
 
 if __name__ == "__main__":
 
-    # Create Process
-    from airflow_provider_aiida.aiida_core.engine.launch import create
+    from airflow_provider_aiida.aiida_core.engine.launch import run_get_node
     from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
     from aiida import load_profile
     from aiida.orm import load_code, Int
@@ -34,21 +33,6 @@ if __name__ == "__main__":
         'y': Int(1),
         #'metadata': {'options': {'sleep': 5}} 
     }
+    result, node = run_get_node(ArithmeticAddCalculation, inputs)
+    print(result, node)
 
-    # TODO Does not work yet
-    #node = create(ArithmeticAddCalculation, inputs)
-
-    process = ArithmeticAddCalculation(inputs=inputs)
-    process._save_checkpoint()
-    node = process.node
-
-
-    dag.test(
-        run_conf={
-            "node_pk": node.pk
-        }
-    )
-
-    print("\n" + "=" * 60)
-    print("DAG test completed!")
-    print("=" * 60)

--- a/src/airflow_provider_aiida/example_dags/multiply_add.py
+++ b/src/airflow_provider_aiida/example_dags/multiply_add.py
@@ -17,7 +17,7 @@ with DAG(
     )
 
 if __name__ == "__main__":
-    from airflow_provider_aiida.aiida_core.engine.launch import create
+    from airflow_provider_aiida.aiida_core.engine.launch import run_get_node
     from aiida import load_profile
     from aiida.orm import load_code, Int
 
@@ -31,15 +31,5 @@ if __name__ == "__main__":
         'z': Int(2),
     }
     
-    # TODO Does not work yet
-    #node = create(MultiplyAddWorkChain, inputs)
-
-    process = MultiplyAddWorkChain(inputs=inputs)
-    process._save_checkpoint()
-    node = process.node
-
-    dag.test(
-        run_conf={
-            "node_pk": node.pk
-        }
-    )
+    output, node = run_get_node(MultiplyAddWorkChain, inputs)
+    print(output, node)

--- a/src/airflow_provider_aiida/triggers/process.py
+++ b/src/airflow_provider_aiida/triggers/process.py
@@ -5,24 +5,39 @@ allowing CalcJob operations to be performed asynchronously in the Airflow trigge
 """
 
 import logging
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, TYPE_CHECKING
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
-from airflow_provider_aiida.aiida_core.engine.runner import Runner
+from airflow_provider_aiida.aiida_core.engine.runner import AirflowRunner
+
+if TYPE_CHECKING:
+    from asyncio import AbstractEventLoop
 
 logger = logging.getLogger(__name__)
+
+
+def get_current_event_loop() -> 'AbstractEventLoop':
+    import asyncio
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop - create a new one
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop
+
 
 def load_process(node_pk: int):
     """reenters same state"""
     from aiida import load_profile
     load_profile()
-    from aiida.engine import persistence
     from plumpy.persistence import LoadSaveContext
-    persister = persistence.AiiDAPersister()
-    saved_state = persister.load_checkpoint(node_pk)
+    loop = get_current_event_loop()
+    runner = AirflowRunner(loop=loop)
+    saved_state = runner.persister.load_checkpoint(node_pk)
     proc = saved_state.unbundle(LoadSaveContext())
-    proc._runner = Runner.get_instance()
+    proc._runner = runner
     return proc
 
 

--- a/tests/example_dags/test_arithmetic_add.py
+++ b/tests/example_dags/test_arithmetic_add.py
@@ -1,9 +1,8 @@
-from airflow_provider_aiida.aiida_core.engine.launch import create
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+from airflow_provider_aiida.aiida_core.engine.launch import run_get_node
 from aiida.orm import Int
 
 # Import the DAG
-from airflow_provider_aiida.example_dags.arithmetic_add import dag
 
 
 def test_arithmetic_add_dag(aiida_code_installed):
@@ -14,16 +13,7 @@ def test_arithmetic_add_dag(aiida_code_installed):
         'x': Int(5),
         'y': Int(10),
     }
-
-    process = ArithmeticAddCalculation(inputs=inputs)
-    process._save_checkpoint()
-    node = process.node
-
-    dag.test(
-        run_conf={
-            "node_pk": node.pk
-        }
-    )
+    result, node = run_get_node(ArithmeticAddCalculation, inputs)
 
     assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}" 
-    assert node.outputs.sum.value == 15
+    assert result.sum.value == 15


### PR DESCRIPTION
The singleton pattern for the Runner caused problems when used in an testing run environment. In this case the single runner instance is created outside of the trigger. The runner with its event loop is forked into the trigger environment still referencing the old event loop where the test run was started. We therefore removed the singleton pattern.

The broker_submit attribue is left as settable in the Runner depending if it is run or submitted.  Note that the for broker submit in airflow the api webserver and scheduler need to be running. There is no check for this at the moment.

Tests and examples have been accordingly updated to use the new function