### PR TITLE
Replace REST API to direct database usage to submit DAG runs

### DIFF
--- a/src/airflow_provider_aiida/aiida_core/engine/launch.py
+++ b/src/airflow_provider_aiida/aiida_core/engine/launch.py
@@ -3,14 +3,13 @@ from aiida.engine.utils import instantiate_process, is_process_scoped, prepare_i
 from aiida.engine.processes.functions import FunctionProcess
 from aiida.engine.processes.process import Process
 from aiida.engine.processes.builder import ProcessBuilder
+from aiida.common.exceptions import ConfigurationError
 
 from aiida.common import InvalidOperation
 from aiida.orm import ProcessNode
 import logging
 import time
 import typing as t
-
-from airflow.api.client import get_current_api_client
 
 if t.TYPE_CHECKING:
     from aiida.engine.runners import ResultAndPk
@@ -57,7 +56,7 @@ def submit(
 
     process_inited = instantiate_process(runner, process, **inputs)
 
-    # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
+    # If adry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
     # instead of raising, because in this way the user does not have to change the launcher when testing. The same goes
     # for if `remote_folder` is present in the inputs, which means we are importing an already completed calculation.
     if process_inited.metadata.get('dry_run', False) or 'remote_folder' in inputs:
@@ -72,9 +71,32 @@ def submit(
     node = process_inited.node
 
     # Do not wait for the future's result, because in the case of a single worker this would cock-block itself
-    get_current_api_client().trigger_dag(
-        dag_id=process_inited.__class__.__name__,
-        conf={"node_pk": node.pk}
+    from airflow.utils.types import DagRunTriggeredByType
+    dag_id = process_inited.__class__.__name__
+
+    from aiida import get_profile
+    try:
+        aiida_profile = get_profile()
+    except ConfigurationError:
+        from aiida import load_profile
+        aiida_profile = load_profile()
+
+    import os
+    aiida_path = os.getenv("AIIDA_PATH", None)
+    conf = {"process_pk": node.pk,
+            "aiida_profile": aiida_profile.name,
+            "aiida_path": aiida_path
+            }
+
+    # NOTE: Raises error when not successfull, the typehint None is a bit confusing, it should not happen 
+    from airflow.api.common import trigger_dag
+    trigger_dag.trigger_dag(
+        dag_id=dag_id,
+        triggered_by=DagRunTriggeredByType.CLI,
+        run_id=None,
+        conf=conf,
+        logical_date=None,
+        replace_microseconds=True,
     )
 
     if not wait:

--- a/src/airflow_provider_aiida/aiida_core/engine/runner.py
+++ b/src/airflow_provider_aiida/aiida_core/engine/runner.py
@@ -15,6 +15,7 @@ from aiida.orm import ProcessNode
 from aiida.common import exceptions
 from aiida.engine.processes import Process, ProcessBuilder
 from aiida.engine.runners import Runner, ResultAndNode
+from aiida.common.exceptions import ConfigurationError
 
 from plumpy.persistence import Persister
 from plumpy.events import set_event_loop_policy
@@ -90,10 +91,23 @@ class AirflowRunner(Runner):
         if dag is None:
             raise ValueError(f"Could not find DAG corresponding to process class {dag_id!r}")
 
+        from aiida import get_profile
+
+        try:
+            aiida_profile = get_profile()
+        except ConfigurationError:
+            from aiida import load_profile
+            aiida_profile = load_profile()
+
+        import os
+        aiida_path = os.getenv("AIIDA_PATH", None)
+        conf = {"process_pk": process_inited.node.pk,
+                "aiida_profile": aiida_profile.name,
+                "aiida_path": aiida_path
+                }
+
         dag.test(
-            run_conf={
-                "node_pk": process_inited.node.pk
-            }
+            run_conf=conf
         )
         return process_inited.outputs, process_inited.node
 
@@ -157,9 +171,21 @@ class AirflowRunner(Runner):
         process_inited_dag_id = process_inited.__class__.__name__ # TODO .build_process_type().replace(":", "-")
 
         if self._broker_submit:
+            from aiida import get_profile
+            from aiida.common.exceptions import ConfigurationError
+
+            try:
+                aiida_profile = get_profile()
+            except ConfigurationError:
+                from aiida import load_profile
+                aiida_profile = load_profile()
+
+            import os
+            aiida_path = os.getenv("AIIDA_PATH", None)
 
             import subprocess
             import sys
+            # TODO we need to pass the environ from the operator
             code_snippet = f"""
 import os
 import sys
@@ -174,13 +200,26 @@ from airflow.configuration import conf
 sql_conn = conf.get('database', 'sql_alchemy_conn', fallback='NOT SET')
 print(f"SQL connection: {{sql_conn if sql_conn != 'NOT SET' else 'NOT SET'}}", file=sys.stderr)
 
-from airflow.api.client import get_current_api_client
-client = get_current_api_client()
+# NOTE: Raises error when not successfull, the typehint None is a bit confusing, it should not happen 
+from airflow.api.common import trigger_dag
+trigger_dag.trigger_dag(
+    dag_id=dag_id,
+    triggered_by=DagRunTriggeredByType.CLI,
+    run_id=None,
+    conf=conf,
+    logical_date=None,
+    replace_microseconds=True,
+)
+
+
 
 # Trigger the DAG run
 client.trigger_dag(
     dag_id='{process_inited_dag_id}',
-    conf={{'node_pk': {process_inited.pid}}}
+    conf={{'process_pk': {process_inited.pid},
+           'aiida_profile': {aiida_profile!r},
+           'aiida_path': {aiida_path!r}
+    }}
 )
 """
             from pathlib import Path

--- a/src/airflow_provider_aiida/example_dags/arithmetic_add.py
+++ b/src/airflow_provider_aiida/example_dags/arithmetic_add.py
@@ -7,20 +7,23 @@ from airflow.models.param import Param
 with DAG(
     'ArithmeticAddCalculation',
     params={
-        "node_pk": Param("", type="integer")
+        "process_pk": Param("", type="integer"),
+        "aiida_profile": Param(None, type=["null", "string"]),
+        "aiida_path": Param(None, type=["null", "string"])
     },
     render_template_as_native_obj = True
 ) as dag:
     ProcessTaskGroup(
         process_class=ArithmeticAddCalculation,
-        node_pk="{{ params.node_pk }}",
+        process_pk="{{ params.process_pk }}",
+        aiida_profile="{{ params.aiida_profile }}",
+        aiida_path="{{ params.aiida_path }}",
     )
 
 
 if __name__ == "__main__":
 
     from airflow_provider_aiida.aiida_core.engine.launch import run_get_node
-    from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
     from aiida import load_profile
     from aiida.orm import load_code, Int
 

--- a/src/airflow_provider_aiida/example_dags/multiply_add.py
+++ b/src/airflow_provider_aiida/example_dags/multiply_add.py
@@ -7,13 +7,17 @@ from airflow.models.param import Param
 with DAG(
     'MultiplyAddWorkChain',
     params={
-        "node_pk": Param("", type="integer")
+        "process_pk": Param("", type="integer"),
+        "aiida_profile": Param(None, type=["null", "string"]),
+        "aiida_path": Param(None, type=["null", "string"])
     },
     render_template_as_native_obj = True
 ) as dag:
     ProcessTaskGroup(
         process_class=MultiplyAddWorkChain,
-        node_pk="{{ params.node_pk }}",
+        process_pk="{{ params.process_pk }}",
+        aiida_profile="{{ params.aiida_profile }}",
+        aiida_path="{{ params.aiida_path }}",
     )
 
 if __name__ == "__main__":

--- a/src/airflow_provider_aiida/operators/process.py
+++ b/src/airflow_provider_aiida/operators/process.py
@@ -11,15 +11,24 @@ from airflow.utils.context import Context
 
 class ProcStepUntilTerminatedOperator(BaseOperator):
 
-    template_fields = ["node_pk"]
+    template_fields = ["process_pk", "aiida_profile", "aiida_path"]
 
-    def __init__(self, node_pk: int, **kwargs):
+    def __init__(self,
+                 process_pk: int,
+                 aiida_profile: str | None,
+                 aiida_path: str | None,
+                 **kwargs):
         super().__init__(**kwargs)
-        self.node_pk = node_pk
+        self.process_pk = process_pk
+        self.aiida_profile = aiida_profile
+        self.aiida_path = aiida_path
 
     def execute(self, context: Context):
         self.defer(
-            trigger=ProcStepUntilTerminatedTrigger(node_pk=self.node_pk),
+            trigger=ProcStepUntilTerminatedTrigger(
+                process_pk=self.process_pk,
+                aiida_profile=self.aiida_profile,
+                aiida_path=self.aiida_path),
             method_name="execute_complete",
         )
 

--- a/src/airflow_provider_aiida/taskgroups/process.py
+++ b/src/airflow_provider_aiida/taskgroups/process.py
@@ -25,7 +25,9 @@ class ProcessTaskGroup(TaskGroup):
     def __init__(
         self,
         process_class,
-        node_pk: int
+        process_pk: int,
+        aiida_profile: str | None,
+        aiida_path: str | None,
     ):
         """Initialize the AiiDA CalcJob TaskGroup.
 
@@ -33,13 +35,17 @@ class ProcessTaskGroup(TaskGroup):
         """
         super().__init__(group_id=process_class.__name__)
         self.process_class = process_class
-        self.node_pk = node_pk
+        self.process_pk = process_pk
+        self.aiida_profile = aiida_profile
+        self.aiida_path = aiida_path
         self._build_tasks()
 
     def _build_tasks(self):
         ProcStepUntilTerminatedOperator(
             task_id="step_until_terminate",
-            node_pk=self.node_pk,
+            process_pk=self.process_pk,
+            aiida_profile=self.aiida_profile,
+            aiida_path=self.aiida_path,
             task_group=self,
         )
 

--- a/src/airflow_provider_aiida/triggers/process.py
+++ b/src/airflow_provider_aiida/triggers/process.py
@@ -28,14 +28,19 @@ def get_current_event_loop() -> 'AbstractEventLoop':
     return loop
 
 
-def load_process(node_pk: int):
+def load_process(process_pk: int, aiida_profile: str | None, aiida_path: str | None):
     """reenters same state"""
+    import os
+    # TODO find a solution that gives understandable error message
+    # NOTE: this conflicts if profiles from different aiida paths are used
+    if aiida_path is not None:
+        os.environ["AIIDA_PATH"] = aiida_path
     from aiida import load_profile
-    load_profile()
+    load_profile(aiida_profile)
     from plumpy.persistence import LoadSaveContext
     loop = get_current_event_loop()
     runner = AirflowRunner(loop=loop)
-    saved_state = runner.persister.load_checkpoint(node_pk)
+    saved_state = runner.persister.load_checkpoint(process_pk)
     proc = saved_state.unbundle(LoadSaveContext())
     proc._runner = runner
     return proc
@@ -44,25 +49,32 @@ def load_process(node_pk: int):
 class ProcStepUntilTerminatedTrigger(BaseTrigger):
     """Trigger that executes the AiiDA task_upload_job function."""
 
-    def __init__(self, node_pk: int):
+    def __init__(self, process_pk: int,
+                 aiida_profile: str | None,
+                 aiida_path: str | None):
         """Initialize the upload trigger.
 
-        :param node_pk: Primary key of the CalcJobNode to upload
+        :param process_pk: Primary key of the CalcJobNode to upload
         """
         super().__init__()
-        self.node_pk = node_pk
+        self.process_pk = process_pk
+        self.aiida_profile = aiida_profile
+        self.aiida_path = aiida_path
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize the trigger for persistence."""
         return (
             "airflow_provider_aiida.triggers.process.ProcStepUntilTerminatedTrigger",
-            {"node_pk": self.node_pk},
+            {"process_pk": self.process_pk,
+            "aiida_profile": self.aiida_profile,
+            "aiida_path": self.aiida_path,
+            },
         )
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Execute the upload task."""
         try:
-            proc = load_process(self.node_pk)
+            proc = load_process(self.process_pk, self.aiida_profile, self.aiida_path)
             await proc.step_until_terminated()
             result = proc.future().result()
 
@@ -72,6 +84,6 @@ class ProcStepUntilTerminatedTrigger(BaseTrigger):
         except Exception as e:
             import traceback
             tb = traceback.format_exc()
-            logger.exception(f"Step until terminated task failed for node {self.node_pk}")
+            logger.exception(f"Step until terminated task failed for node {self.process_pk}")
             yield TriggerEvent({"status": "error", "message": str(e), "traceback": tb})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,3 @@
-pytest_plugins = ["aiida.tools.pytest_fixtures"]
+from aiida import load_profile
+
+load_profile()

--- a/tests/example_dags/test_arithmetic_add.py
+++ b/tests/example_dags/test_arithmetic_add.py
@@ -1,19 +1,34 @@
+import pytest
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
-from airflow_provider_aiida.aiida_core.engine.launch import run_get_node
-from aiida.orm import Int
-
-# Import the DAG
+from airflow_provider_aiida.aiida_core.engine.launch import run_get_node, submit
+from aiida.orm import Int, load_code
 
 
-def test_arithmetic_add_dag(aiida_code_installed):
-    """Test the ArithmeticAddCalculation DAG"""
+def test_arithmetic_add_dag_test_run():
+    """Test the ArithmeticAddCalculation DAG in testing runtime environment"""
 
     inputs = {
-        'code': aiida_code_installed(default_calc_job_plugin='core.arithmetic.add'),
+        'code': load_code('bash@localhost'),
         'x': Int(5),
         'y': Int(10),
     }
-    result, node = run_get_node(ArithmeticAddCalculation, inputs)
+    # TODO result is empty dict is this normal?
+    _, node = run_get_node(ArithmeticAddCalculation, inputs)
 
     assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}" 
-    assert result.sum.value == 15
+    assert node.outputs.sum.value == 15
+
+
+def test_arithmetic_add_trigger_run():
+    """Test the triggered ArithmeticAddCalculation DAG with airflow services"""
+
+    inputs = {
+        'code': load_code('bash@localhost'),
+        'x': Int(5),
+        'y': Int(10),
+    }
+    # TODO: add timeout
+    node = submit(ArithmeticAddCalculation, inputs, wait=True)
+
+    assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}" 
+    assert node.outputs.sum.value == 15


### PR DESCRIPTION
Add test for triggering the ArithemticAddCalculation corresponding DAG.

Adapt tests to use current aiida profile in the environment.

Provide aiida profile and config path for the process DAG so test profiles and nondefault profiles can be run.

Add tests for MultiplyAddWorkChain corresponding DAG.