### PR TITLE
Fix usage of old event loop

### DIFF
--- a/src/airflow_provider_aiida/triggers/process.py
+++ b/src/airflow_provider_aiida/triggers/process.py
@@ -43,6 +43,8 @@ def load_process(process_pk: int, aiida_profile: str | None, aiida_path: str | N
     saved_state = runner.persister.load_checkpoint(process_pk)
     proc = saved_state.unbundle(LoadSaveContext())
     proc._runner = runner
+    # NOTE: Overwrite persisted loop since loop might have changed
+    proc._loop = loop
     return proc
 
 


### PR DESCRIPTION
The process also stores the event loop when serialized. This causes issues when the process is initiated in one event loop and then is picked up in a different process with a different event loop.