### PR TITLE
Configure test infrastructure with PostgreSQL and Airflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Runinng tests
+
+## Testing environment
+
+The test environment (`hatch-test`) is configured in `pyproject.toml` with:
+- PostgreSQL connection on port 5434
+- Airflow home directory in `.pytest/airflow`
+- Custom DAG bundle configuration
+- Test dependencies (pytest, psycopg2-binary, asyncpg)
+
+## Start PostgreSQL service
+
+The test environment uses PostgreSQL on port 5434. Start the PostgreSQL service:
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+```
+
+Check if the service is running:
+
+```bash
+docker ps
+```
+
+Expected output:
+```
+CONTAINER ID   IMAGE         COMMAND                  CREATED      STATUS                PORTS                                         NAMES
+6de79ae7f116   postgres:14   "docker-entrypoint.s…"   2 days ago   Up 2 days (healthy)   0.0.0.0:5434->5432/tcp, [::]:5434->5432/tcp   airflow-provider-aiida-postgres-1
+```
+
+## Run unit tests
+
+For regular unit tests that don't require Airflow services:
+
+```bash
+hatch test
+```
+
+This runs all non-integration tests using pytest.
+To clean test artifacts including airflow.cfg and logs.
+```bash
+hatch run hatch-test.py3.11:clean
+```
+
+## Integration tests
+
+Integration tests require running Airflow services (scheduler, triggerer, dag-processor). These tests are marked with `@pytest.mark.integration`.
+
+
+### Start airflow services
+
+In separate terminal windows/tabs, start each service:
+
+```bash
+# Terminal 1: Scheduler
+hatch run hatch-test.py3.11:scheduler
+
+# Terminal 2: Triggerer
+hatch run hatch-test.py3.11:triggerer
+
+# Terminal 3: DAG Processor
+hatch run hatch-test.py3.11:dag-processor
+
+# Terminal 4: API Server
+hatch run hatch-test.py3.11:api-server
+```
+
+### Run integration tests
+
+```bash
+hatch run hatch-test.py3.11:integration
+```
+
+Or use hatch test with pytest args:
+
+```bash
+hatch test -- -m integration
+```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+# Minimal Docker Compose - PostgreSQL only for testing
+# Airflow services (scheduler, triggerer) are managed by the process manager
+
+services:
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    ports:
+      - "${AIRFLOW_PROVIDER_AIIDA__POSTGRES_HOST_PORT:-5432}:5432"
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+
+volumes:
+  postgres-db-volume:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,21 +53,42 @@ allow-direct-references = true
 python = "3.11"
 
 [tool.hatch.envs.hatch-test]
-default-args = []
+default-args = ["tests"]
+dependencies = [
+    "pytest>=7.0",
+    "pytest-mock>=3.10",
+    # NOTE: these are requirements only needed with psql
+    "psycopg2-binary>=2.9.0",
+    "asyncpg>=0.29.0",
+]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.11"]
 
-[tool.hatch.envs.test]
-python = "3.11"
-dependencies = [
-    "pytest>=7.0",
-    "pytest-mock>=3.10",
-]
+[tool.hatch.envs.hatch-test.env-vars]
+AIRFLOW_HOME = "{root}/.pytest/airflow"
+AIRFLOW_PROVIDER_AIIDA__POSTGRES_HOST_PORT = "5434"
+AIRFLOW__DATABASE__SQL_ALCHEMY_CONN = "postgresql+psycopg2://airflow:airflow@127.0.0.1:5434/airflow"
+AIRFLOW__CORE__DAGS_FOLDER = "{root}/src/airflow_provider_aiida/example_dags"
+AIRFLOW__CORE__LOAD_EXAMPLES = "False"
+AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS = "False"
+AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST = '[{{"name":"dags-folder","classpath":"airflow.dag_processing.bundles.local.LocalDagBundle","kwargs":{{}}}},{{"name":"aiida_dags","classpath":"airflow_provider_aiida.bundles.aiida_dag_bundle.AiidaDagBundle","kwargs":{{}}}}]'
 
-[tool.hatch.envs.test.scripts]
-run = "pytest {args:tests}"
-cov = "pytest --cov-report=term-missing --cov=airflow_provider_aiida {args:tests}"
+[tool.hatch.envs.hatch-test.scripts]
+# Start Airflow services (for integration testing)
+scheduler = "airflow scheduler"
+api-server = "airflow api-server"
+triggerer = "airflow triggerer"
+dag-processor = "airflow dag-processor"
+
+# Run integration tests
+integration = "pytest -m integration tests"
+
+# Clean test artifacts
+clean = [
+    "rm -rf .pytest",
+    "echo 'Cleaned .pytest directory'",
+]
 
 [tool.setuptools]
 include-package-data = false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,68 @@
+import pytest
 from aiida import load_profile
 
 load_profile()
+
+
+@pytest.fixture(scope='session')
+def bash_code():
+    """Create and return the bash@localhost code for tests.
+
+    This fixture automatically sets up:
+    1. The localhost computer (if not exists)
+    2. The bash@localhost code (if not exists)
+
+    Returns the bash code that can be used in arithmetic calculations.
+    """
+    from shutil import which
+    from aiida.common import exceptions
+    from aiida.orm import InstalledCode, load_code
+
+    try:
+        code = load_code('bash@localhost')
+    except exceptions.NotExistent:
+        # Prepare localhost computer
+        localhost = _prepare_localhost()
+
+        # Create bash code
+        code = InstalledCode(
+            label='bash',
+            computer=localhost,
+            filepath_executable=which('bash'),
+            default_calc_job_plugin='core.arithmetic.add',
+        ).store()
+
+    return code
+
+
+def _prepare_localhost():
+    """Prepare and return the localhost computer.
+
+    If it doesn't already exist, the computer will be created using:
+    - Transport: core.local
+    - Scheduler: core.direct
+    - Safe interval: 0 seconds (for fast testing)
+    - Minimum job poll interval: 0 seconds (for fast testing)
+    """
+    import tempfile
+    from aiida.common import exceptions
+    from aiida.orm import Computer, load_computer
+
+    try:
+        computer = load_computer('localhost')
+    except exceptions.NotExistent:
+        computer = Computer(
+            label='localhost',
+            hostname='localhost',
+            description='Localhost automatically created for tests',
+            transport_type='core.local',
+            scheduler_type='core.direct',
+            workdir=tempfile.gettempdir(),
+        ).store()
+        computer.configure(safe_interval=0.0)
+        computer.set_minimum_job_poll_interval(0.0)
+
+    if not computer.is_configured:
+        computer.configure()
+
+    return computer

--- a/tests/example_dags/test_arithmetic_add.py
+++ b/tests/example_dags/test_arithmetic_add.py
@@ -1,34 +1,35 @@
 import pytest
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from airflow_provider_aiida.aiida_core.engine.launch import run_get_node, submit
-from aiida.orm import Int, load_code
+from aiida.orm import Int
 
 
-def test_arithmetic_add_dag_test_run():
+def test_arithmetic_add_dag_test_run(bash_code):
     """Test the ArithmeticAddCalculation DAG in testing runtime environment"""
 
     inputs = {
-        'code': load_code('bash@localhost'),
+        'code': bash_code,
         'x': Int(5),
         'y': Int(10),
     }
     # TODO result is empty dict is this normal?
     _, node = run_get_node(ArithmeticAddCalculation, inputs)
 
-    assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}" 
+    assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}"
     assert node.outputs.sum.value == 15
 
 
-def test_arithmetic_add_trigger_run():
+@pytest.mark.integration
+def test_arithmetic_add_trigger_run(bash_code):
     """Test the triggered ArithmeticAddCalculation DAG with airflow services"""
 
     inputs = {
-        'code': load_code('bash@localhost'),
+        'code': bash_code,
         'x': Int(5),
         'y': Int(10),
     }
     # TODO: add timeout
     node = submit(ArithmeticAddCalculation, inputs, wait=True)
 
-    assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}" 
+    assert not node.is_failed, "Calculation failed, exit status: {node.exit_status}, exit message: {node.exit_message}"
     assert node.outputs.sum.value == 15


### PR DESCRIPTION
Tests use PostgreSQL exclusively for simplicity at this stage. A separate test database service is provided via docker-compose to isolate from production environments.

Integration tests require Airflow services (scheduler, triggerer, dag-processor, api-server) to be started manually before running tests. This allows for easier debugging during development.

Changes:
- Add docker-compose.test.yml for PostgreSQL on port 5434
- Configure hatch-test environment with test dependencies
- Add bash@localhost code fixture in conftest.py
- Mark integration tests with @pytest.mark.integration
- Update CONTRIBUTING.md with testing instructions