### PR TITLE
Initialization of test profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,51 @@
-# Runinng tests
+# Run tests
 
-## Testing environment
+## Quick start
+
+To run only unit tests that do not require and Airflow services to be started.
+
+```bash
+# 1. Start PostgreSQL with docker compose
+hatch run hatch-test.py3.11:start-psql-service
+
+# 2. Create AiiDA profile and databases
+hatch run hatch-test.py3.11:setup-profile
+
+# 4. Run unit tests
+hatch run hatch-test.py3.11:unit-tests
+```
+
+## Unit tests
+
+### Setup test environment
 
 The test environment (`hatch-test`) is configured in `pyproject.toml` with:
 - PostgreSQL connection on port 5434
-- Airflow home directory in `.pytest/airflow`
+- AiiDA configuration in `.pytest/.aiida/`
+- AiiDA profile named `test`
+- Airflow home directory in `.pytest/.aiida/test/airflow/`
 - Custom DAG bundle configuration
 - Test dependencies (pytest, psycopg2-binary, asyncpg)
 
-## Start PostgreSQL service
+The `hatch-test` environment automatically sets these required environment variables.
+Please check the environment variables in the `hatch-test` environment and how the scripts use them if you want to adapt them to your own.
+**Important:** Tests and setup scripts **require** these environment variables. They are automatically set when using the scripts `hatch run hatch-test.py3.11:*` commands.
+If you want to run tests manually outside of hatch, you must set them yourself.
 
-The test environment uses PostgreSQL on port 5434. Start the PostgreSQL service:
+#### 1. Start PostgreSQL service
+
+The test environment uses PostgreSQL. Start the PostgreSQL service:
 
 ```bash
-docker compose -f docker-compose.test.yml up -d
+hatch run hatch-test.py3.11:start-psql-service
 ```
+
+This will start PostgreSQL on port 5434 with the admin user `postgres` (password: `postgres`).
 
 Check if the service is running:
 
 ```bash
-docker ps
+hatch run hatch-test.py3.11:status-psql-service
 ```
 
 Expected output:
@@ -28,28 +54,68 @@ CONTAINER ID   IMAGE         COMMAND                  CREATED      STATUS       
 6de79ae7f116   postgres:14   "docker-entrypoint.s…"   2 days ago   Up 2 days (healthy)   0.0.0.0:5434->5432/tcp, [::]:5434->5432/tcp   airflow-provider-aiida-postgres-1
 ```
 
-## Run unit tests
+#### 2. Setup AiiDA test profile
+
+Create the AiiDA test profile that uses the PostgreSQL on port 5434:
+
+```bash
+hatch run hatch-test.py3.11:setup-profile
+```
+
+This script will:
+1. Create a PostgreSQL user `aiida-test` with password `password`
+2. Create two databases owned by `aiida-test`:
+   - `aiida-test`: AiiDA database
+   - `airflow-test`: Airflow database
+3. Create an AiiDA profile named `test` using the `aiida-test` database
+4. Initialize the AiiDA storage (create tables)
+5. Set the profile as the default AiiDA profile
+6. Initialize the Airflow database (run migrations)
+7. Set up the Airflow home directory structure
+
+**Database Hierarchy:**
+```
+postgres (admin)
+  └── aiida-test (user created by setup-profile)
+       ├── aiida-test (database for AiiDA)
+       └── airflow-test (database for Airflow)
+```
+
+The profile will be located at `.pytest/.aiida/test/` (or `$AIIDA_PATH/.aiida/test/` if `AIIDA_PATH` is set) with the following structure:
+```
+.pytest/.aiida/test/
+└── airflow/                    # Airflow files
+    ├── dags/                   # DAG files
+    └── airflow.cfg             # Airflow configuration
+```
+
+**Note:** If the profile already exists, the script will recreate it. If you choose to recreate, it will:
+- Remove the existing AiiDA profile configuration
+- Drop both aiida and airflow databases
+- Drop the aiida `test` user
+- Recreate everything from scratch
+
+## Run unit test
 
 For regular unit tests that don't require Airflow services:
 
 ```bash
-hatch test
+hatch run hatch-test.py3.11:unit-tests
 ```
 
-This runs all non-integration tests using pytest.
-To clean test artifacts including airflow.cfg and logs.
+Or use hatch test with pytest args:
+
 ```bash
-hatch run hatch-test.py3.11:clean
+hatch test -- -m 'not integration'
 ```
 
-## Integration tests
+## Run integration tests
 
 Integration tests require running Airflow services (scheduler, triggerer, dag-processor). These tests are marked with `@pytest.mark.integration`.
 
+### Start Airflow services in foreground (recommended for debugging)
 
-### Start airflow services
-
-In separate terminal windows/tabs, start each service:
+If you prefer to start services manually in separate terminals:
 
 ```bash
 # Terminal 1: Scheduler
@@ -67,6 +133,8 @@ hatch run hatch-test.py3.11:api-server
 
 ### Run integration tests
 
+Once services are running, run the integration tests:
+
 ```bash
 hatch run hatch-test.py3.11:integration
 ```
@@ -75,4 +143,25 @@ Or use hatch test with pytest args:
 
 ```bash
 hatch test -- -m integration
+```
+
+##  Run all tests
+
+After setup you can run all tests using
+
+```bash
+hatch test
+```
+
+## Clean test artifacts
+
+Be sure that all airflow services and the docker service have been stopped.
+The docker service can be stopped with.
+```
+hatch run hatch-test.py3.11:stop-psql-service
+```
+
+To clean test artifacts including the PostgreSQL databasese cluster, as well as the aiida and the airflow config.
+```bash
+hatch run hatch-test.py3.11:clean
 ```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,15 +7,15 @@ services:
   postgres:
     image: postgres:14
     environment:
-      POSTGRES_USER: airflow
-      POSTGRES_PASSWORD: airflow
-      POSTGRES_DB: airflow
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
     ports:
-      - "${AIRFLOW_PROVIDER_AIIDA__POSTGRES_HOST_PORT:-5432}:5432"
+      - "${POSTGRES_HOST_PORT}:5432"
     volumes:
       - postgres-db-volume:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "airflow"]
+      test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       retries: 5
       start_period: 5s

--- a/examples/trigger_arithmetic_add.py
+++ b/examples/trigger_arithmetic_add.py
@@ -1,7 +1,7 @@
 # Create Process
 from airflow_provider_aiida.aiida_core.engine.launch import submit
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
-from aiida import load_profile
+from airflow_provider_aiida.aiida_core import load_profile
 load_profile()
 from aiida.orm import load_code, Int
 code = load_code('bash@localhost')

--- a/examples/trigger_multiply_add.py
+++ b/examples/trigger_multiply_add.py
@@ -1,7 +1,7 @@
 # Create Process
 from airflow_provider_aiida.aiida_core.engine.launch import submit
 from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain 
-from aiida import load_profile
+from airflow_provider_aiida.aiida_core import load_profile
 load_profile()
 from aiida.orm import load_code, Int
 code = load_code('bash@localhost')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ allow-direct-references = true
 python = "3.11"
 
 [tool.hatch.envs.hatch-test]
-default-args = ["tests"]
+default-args = []
 dependencies = [
     "pytest>=7.0",
     "pytest-mock>=3.10",
@@ -66,28 +66,54 @@ dependencies = [
 python = ["3.11"]
 
 [tool.hatch.envs.hatch-test.env-vars]
-AIRFLOW_HOME = "{root}/.pytest/airflow"
-AIRFLOW_PROVIDER_AIIDA__POSTGRES_HOST_PORT = "5434"
-AIRFLOW__DATABASE__SQL_ALCHEMY_CONN = "postgresql+psycopg2://airflow:airflow@127.0.0.1:5434/airflow"
-AIRFLOW__CORE__DAGS_FOLDER = "{root}/src/airflow_provider_aiida/example_dags"
-AIRFLOW__CORE__LOAD_EXAMPLES = "False"
-AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS = "False"
-AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST = '[{{"name":"dags-folder","classpath":"airflow.dag_processing.bundles.local.LocalDagBundle","kwargs":{{}}}},{{"name":"aiida_dags","classpath":"airflow_provider_aiida.bundles.aiida_dag_bundle.AiidaDagBundle","kwargs":{{}}}}]'
+# PostgreSQL configuration (shared by Airflow and AiiDA)
+POSTGRES_HOST = "127.0.0.1"
+POSTGRES_HOST_PORT = "5434"
+POSTGRES_USER = "postgres"
+POSTGRES_PASSWORD = "postgres"
+
+
+# AiiDA configuration
+AIIDA_PATH = "{root}/.pytest"
+AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE = "test"
+AIRFLOW_PROVIDER_AIIDA__TESTS__AIRFLOW_POSTGRES_PASSWORD = "password"
 
 [tool.hatch.envs.hatch-test.scripts]
-# Start Airflow services (for integration testing)
-scheduler = "airflow scheduler"
-api-server = "airflow api-server"
-triggerer = "airflow triggerer"
-dag-processor = "airflow dag-processor"
+# Setup test environment
+setup-profile = [
+  "python scripts/cmd_profile_create.py --postgres-host {env:POSTGRES_HOST} --postgres-port {env:POSTGRES_HOST_PORT} --postgres-user {env:POSTGRES_USER} --postgres-password {env:POSTGRES_PASSWORD} --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} --aiida-password {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIRFLOW_POSTGRES_PASSWORD}",
+]
+reserialize = [
+  "python scripts/cmd_airflow.py --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} dags reserialize --bundle-name aiida_dags",
+]
+
+teardown-profile = [
+  "python scripts/cmd_profile_delete.py --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} --postgres-user {env:POSTGRES_USER} --postgres-password {env:POSTGRES_PASSWORD}"
+]
+
+# Process manager commands
+start-psql-service = "docker compose -f docker-compose.test.yml up -d"
+stop-psql-service = "docker compose -f docker-compose.test.yml down -v"
+status-psql-service = "docker ps"
+
+# Start individual Airflow services (for manual testing)
+scheduler = "python scripts/cmd_airflow.py --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} scheduler"
+api-server = "python scripts/cmd_airflow.py --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} api-server"
+triggerer = "python scripts/cmd_airflow.py --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} triggerer"
+dag-processor = "python scripts/cmd_airflow.py --profile-name {env:AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE} dag-processor"
 
 # Run integration tests
-integration = "pytest -m integration tests"
+unit-tests = "pytest -m 'not integration' {args:{root}/tests}"
+integration-tests = "pytest -m 'integration' {args:{root}/tests}"
+# Default test runner - excludes integration tests, only runs tests/ directory
+run = "pytest {args:{root}/tests}"
 
 # Clean test artifacts
+# NOTE: Only use after services have been stopped to
 clean = [
     "rm -rf .pytest",
-    "echo 'Cleaned .pytest directory'",
+    "docker volume rm -f airflow-provider-aiida_postgres-db-volume",
+    "echo 'Cleaned Docker volumes and .pytest directory'",
 ]
 
 [tool.setuptools]
@@ -103,6 +129,9 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that require Airflow services to be running (scheduler, triggerer)",
+]
 filterwarnings = [
     # AiiDA SQLAlchemy warnings - these are expected and safe to ignore as done in aiida-core
     "ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning",

--- a/scripts/cmd_airflow.py
+++ b/scripts/cmd_airflow.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""
+Run Airflow CLI commands using an AiiDA profile's configuration.
+
+This script loads an AiiDA profile (default or specified), extracts the Airflow environment
+configuration, and executes the provided Airflow CLI command with those settings.
+
+Example usage:
+    python scripts/cmd_airflow.py db migrate
+    python scripts/cmd_airflow.py dags list
+    python scripts/cmd_airflow.py scheduler
+    python scripts/cmd_airflow.py --profile-name test scheduler
+"""
+
+import sys
+import os
+import subprocess
+from airflow_provider_aiida.aiida_core import load_profile
+
+
+def main():
+    """Main function."""
+    # Extract --profile-name argument if present, keeping other args for Airflow
+    profile_name = None
+    airflow_args = []
+
+    i = 0
+    args = sys.argv[1:]
+    while i < len(args):
+        if args[i] == '--profile-name':
+            if i + 1 < len(args):
+                profile_name = args[i + 1]
+                i += 2  # Skip both --profile-name and its value
+            else:
+                print("Error: --profile-name requires a value")
+                return 1
+        else:
+            airflow_args.append(args[i])
+            i += 1
+
+    if not airflow_args:
+        print("Usage: {} [--profile-name PROFILE] [airflow_command] [airflow_args...]".format(sys.argv[0]))
+        print("\nOptions:")
+        print("  --profile-name PROFILE    Use specified AiiDA profile (default: default profile)")
+        print("\nExamples:")
+        print("  {} db migrate                      # Initialize/migrate Airflow database".format(sys.argv[0]))
+        print("  {} dags list                       # List all DAGs".format(sys.argv[0]))
+        print("  {} dags reserialize -B aiida_dags  # Reserialize DAGs".format(sys.argv[0]))
+        print("  {} scheduler                       # Start the scheduler".format(sys.argv[0]))
+        print("  {} triggerer                       # Start the triggerer".format(sys.argv[0]))
+        print("  {} --profile-name test scheduler   # Start scheduler with 'test' profile".format(sys.argv[0]))
+        return 1
+
+    try:
+        # Load the AiiDA profile
+        from airflow_provider_aiida.aiida_core import load_profile
+        load_profile(profile_name)
+
+
+        # Build the airflow command
+        airflow_command = ['airflow'] + airflow_args
+
+        print(f"Running: {' '.join(airflow_command)}")
+        print("=" * 60)
+        print()
+
+        # Execute the airflow command with the configured environment
+        result = subprocess.run(
+            airflow_command,
+            env=os.environ
+        )
+
+        # Return the same exit code as the airflow command
+        return result.returncode
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cmd_profile_create.py
+++ b/scripts/cmd_profile_create.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Setup AiiDA profile using the same PostgreSQL.
+"""
+
+import sys
+import os
+import argparse
+from airflow_provider_aiida.aiida_core.manage.configuration.config import create_aiida_profile 
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Setup AiiDA and Airflow profiles using PostgreSQL",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        '--postgres-host',
+        default=os.getenv('POSTGRES_HOST', '127.0.0.1'),
+        help='PostgreSQL server hostname (default: from POSTGRES_HOST env or 127.0.0.1)'
+    )
+
+    parser.add_argument(
+        '--postgres-port',
+        type=int,
+        default=int(os.getenv('POSTGRES_HOST_PORT', '5432')),
+        help='PostgreSQL server port (default: from POSTGRES_HOST_PORT env or 5434)'
+    )
+
+    parser.add_argument(
+        '--postgres-user',
+        default=os.getenv('POSTGRES_USER', 'postgres'),
+        help='PostgreSQL admin user with CREATEDB and CREATEROLE privileges (default: from POSTGRES_USER env or postgres)'
+    )
+
+    parser.add_argument(
+        '--postgres-password',
+        default=os.getenv('POSTGRES_PASSWORD', 'postgres'),
+        help='PostgreSQL admin user password (default: from POSTGRES_PASSWORD env or postgres)'
+    )
+
+    parser.add_argument(
+        '--aiida-password',
+        default=os.getenv('AIIDA_PASSWORD', 'password'),
+        help='PostgreSQL aiida user password (default: just password)'
+    )
+
+    parser.add_argument(
+        '--profile-name',
+        default=os.getenv('AIIDA_PROFILE', 'presto'),
+        help='AiiDA profile name (default: presto)'
+    )
+
+    return parser.parse_args()
+
+def main():
+    """Main function."""
+    try:
+        args = parse_arguments()
+
+        profile_parameters = {
+            'pg_host': args.postgres_host,
+            'pg_port': args.postgres_port,
+            'pg_admin_user': args.postgres_user,
+            'pg_admin_password': args.postgres_password,
+            'profile_name': args.profile_name,
+            'overwrite': True
+        }
+
+        profile = create_aiida_profile(**profile_parameters)
+
+        if profile is None:
+            return 1
+
+        return 0
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cmd_profile_delete.py
+++ b/scripts/cmd_profile_delete.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""
+Teardown AiiDA test profile and clean up databases.
+
+This script is designed to be run via hatch:
+    hatch run hatch-test.py3.11:teardown-profile
+"""
+
+import sys
+import os
+import argparse
+from airflow_provider_aiida.aiida_core.manage.configuration.config import delete_aiida_profile
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Teardown AiiDA and Airflow test profiles and clean up databases",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+This script will:
+  1. Verify the profile has Airflow support
+  2. Drop both aiida-<profile> and airflow-<profile> databases
+  3. Drop the PostgreSQL user
+  4. Remove the AiiDA profile configuration
+
+Database connection info (host, port) is extracted from the profile's storage config.
+
+WARNING: This will permanently delete all data in the profile!
+        """
+    )
+
+    parser.add_argument(
+        '--profile-name',
+        default=os.getenv('AIIDA_PROFILE', 'test'),
+        help='AiiDA profile name (default: from AIIDA_PROFILE env or test)'
+    )
+
+    parser.add_argument(
+        '--postgres-user',
+        default=os.getenv('POSTGRES_USER', 'postgres'),
+        help='PostgreSQL admin user with privileges to drop databases and users (default: from POSTGRES_USER env or postgres)'
+    )
+
+    parser.add_argument(
+        '--postgres-password',
+        default=os.getenv('POSTGRES_PASSWORD', 'postgres'),
+        help='PostgreSQL admin user password (default: from POSTGRES_PASSWORD env or postgres)'
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """Main function."""
+    try:
+        args = parse_arguments()
+        delete_aiida_profile(
+            profile_name=args.profile_name,
+            pg_admin_user=args.postgres_user,
+            pg_admin_password=args.postgres_password
+        )
+
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cmd_unpause_dags.py
+++ b/scripts/cmd_unpause_dags.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""
+Unpause all DAGs from a specific bundle.
+
+This script uses Airflow's Python API to directly update the database,
+avoiding issues with DAG import errors that break JSON output.
+
+Usage:
+    python scripts/cmd_unpause_dags.py --bundle aiida_dags
+"""
+
+import sys
+import os
+import argparse
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Unpause all DAGs from a specific bundle",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        '--bundle',
+        required=True,
+        help='DAG bundle name (e.g., aiida_dags)'
+    )
+
+    return parser.parse_args()
+
+
+def setup_airflow_environment():
+    """Load AiiDA profile and set up Airflow environment variables."""
+    from aiida import load_profile
+    from airflow_provider_aiida.utils.profile import from_profile_create_airflow_env
+
+    # Load the default AiiDA profile
+    profile = load_profile()
+
+    # Get Airflow environment variables from the profile
+    airflow_env = from_profile_create_airflow_env(profile)
+
+    # Update current environment with Airflow settings
+    os.environ.update(airflow_env)
+
+    return profile
+
+
+def unpause_dags_by_bundle(bundle_name: str) -> int:
+    """
+    Unpause all DAGs belonging to the specified bundle.
+
+    Args:
+        bundle_name: The bundle name to filter by
+
+    Returns:
+        Number of DAGs unpaused
+    """
+    # Import Airflow modules after environment is set up
+    from airflow.settings import Session
+    from airflow.models.dag import DagModel
+
+    session = Session()
+
+    try:
+        # Query all DAGs with the specified bundle that are currently paused
+        paused_dags = session.query(DagModel).filter(
+            DagModel.bundle_name == bundle_name,
+            DagModel.is_paused == True
+        ).all()
+
+        if not paused_dags:
+            print(f"No paused DAGs found for bundle '{bundle_name}'")
+            return 0
+
+        # Unpause each DAG
+        count = 0
+        for dag in paused_dags:
+            dag.is_paused = False
+            count += 1
+            print(f"Unpaused DAG: {dag.dag_id}")
+
+        session.commit()
+        print(f"\nSuccessfully unpaused {count} DAG(s) from bundle '{bundle_name}'")
+        return count
+
+    except Exception as e:
+        session.rollback()
+        print(f"Error unpausing DAGs: {e}", file=sys.stderr)
+        raise
+    finally:
+        session.close()
+
+
+def main():
+    """Main function."""
+    try:
+        args = parse_arguments()
+
+        # Set up Airflow environment from AiiDA profile
+        print("Loading AiiDA profile and configuring Airflow environment...")
+        setup_airflow_environment()
+        print("✓ Environment configured\n")
+
+        # Unpause DAGs
+        unpause_dags_by_bundle(args.bundle)
+        return 0
+    except Exception as e:
+        print(f"\n✗ Error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/airflow_provider_aiida/aiida_core/__init__.py
+++ b/src/airflow_provider_aiida/aiida_core/__init__.py
@@ -1,0 +1,3 @@
+from airflow_provider_aiida.aiida_core.manage.configuration import load_profile
+
+__all__ = ["load_profile"]

--- a/src/airflow_provider_aiida/aiida_core/manage/configuration/__init__.py
+++ b/src/airflow_provider_aiida/aiida_core/manage/configuration/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+from airflow_provider_aiida.aiida_core.manage.configuration.config import get_airflow_home
+
+
+__all__ = (
+    'load_profile',
+)
+
+def load_profile(profile_name: str | None = None):
+    from aiida import load_profile
+    profile = load_profile() if profile_name is None else load_profile(profile_name)
+    airflow_home = get_airflow_home(profile) 
+    os.environ.update({'AIRFLOW_HOME': str(airflow_home)})
+    return profile
+

--- a/src/airflow_provider_aiida/aiida_core/manage/configuration/_postgres_utils.py
+++ b/src/airflow_provider_aiida/aiida_core/manage/configuration/_postgres_utils.py
@@ -1,0 +1,207 @@
+import psycopg
+import logging
+
+logger = logging.getLogger(__name__)
+
+class PostgreSqlProfileCommands:
+    """Static methods for PostgreSQL database and user management operations."""
+
+    MAX_NAMING_ATTEMPTS = 100
+
+    @staticmethod
+    def db_exists(conn: 'psycopg.Connection', database_name: str) -> bool:
+        """Check whether a postgres database with dbname exists.
+
+        :param conn: PostgreSQL connection object
+        :param database_name: Name of the database to check for
+        :return: True if database exists, False otherwise
+        """
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT datname FROM pg_database WHERE datname = %s",
+                (database_name,)
+            )
+            output = cursor.fetchone()
+        return bool(output) 
+
+    @staticmethod
+    def user_exists(conn: 'psycopg.Connection', database_username: str) -> bool:
+        """Check whether a postgres user exists.
+
+        :param conn: PostgreSQL connection object
+        :param database_username: Name of the user to check for
+        :return: True if user exists, False otherwise
+        """
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT usename FROM pg_user WHERE usename = %s",
+                (database_username,)
+            )
+            output = cursor.fetchone()
+        return bool(output)
+
+
+    @staticmethod
+    def create_db(conn: 'psycopg.Connection', database_name: str, database_owner: str) -> None:
+        """Create a PostgreSQL database with the specified owner.
+
+        Note: CREATE DATABASE cannot run inside a transaction, so the connection
+        should be in autocommit mode.
+
+        :param conn: PostgreSQL connection object (should be in autocommit mode)
+        :param database_name: Name of the database to create
+        :param database_owner: Username of the database owner
+        """
+        with conn.cursor() as cursor:
+            # Use SQL identifiers properly to avoid SQL injection
+            cursor.execute(
+                psycopg.sql.SQL("CREATE DATABASE {} OWNER {}").format(
+                    psycopg.sql.Identifier(database_name),
+                    psycopg.sql.Identifier(database_owner)
+                )
+            )
+
+    @staticmethod
+    def create_user(conn: 'psycopg.Connection', username: str, password: str) -> None:
+        """Create a PostgreSQL user with the specified password.
+
+        :param conn: PostgreSQL connection object
+        :param username: Username to create
+        :param password: Password for the user
+        """
+        with conn.cursor() as cursor:
+            # Use SQL identifiers and literals properly to avoid SQL injection
+            cursor.execute(
+                psycopg.sql.SQL("CREATE USER {} WITH PASSWORD {}").format(
+                    psycopg.sql.Identifier(username),
+                    psycopg.sql.Literal(password)
+                )
+            )
+
+    @staticmethod
+    def create_db_from_dbname_template(conn: 'psycopg.Connection', dbname_template: str, dbowner: str) -> str:
+        """
+        Safely create a PostgreSQL database, handling naming conflicts.
+
+        If a database with the given name already exists, this function will append
+        a numeric suffix (-1, -2, etc.) to create a unique database name.
+
+        Note: CREATE DATABASE cannot run inside a transaction in PostgreSQL, so the
+        connection should be in autocommit mode.
+
+        Args:
+            conn: PostgreSQL connection object (should be in autocommit mode)
+            dbname_template: Desired database name template
+            dbowner: Username of the database owner (must already exist)
+
+        Returns:
+            str: The actual database name that was created (may differ from desired if conflicts exist)
+
+        Raises:
+            RuntimeError: If unable to find a unique database name after MAX_NAMING_ATTEMPTS tries
+        """
+        actual_dbname = dbname_template
+        counter = 1
+
+        for _ in range(PostgreSqlProfileCommands.MAX_NAMING_ATTEMPTS):
+            # Try to create the database
+            db_exists = PostgreSqlProfileCommands.db_exists(conn, actual_dbname)
+            if db_exists:
+                actual_dbname = f"{dbname_template}-{counter}"
+                counter += 1
+            else:
+                break
+        else:
+            raise RuntimeError(
+                f"Could not find a unique database name after {PostgreSqlProfileCommands.MAX_NAMING_ATTEMPTS} attempts. "
+                f"Last tried: {actual_dbname}"
+            )
+
+        PostgreSqlProfileCommands.create_db(conn, actual_dbname, dbowner)
+        logger.info(f"Created PostgreSQL database '{actual_dbname}' with owner '{dbowner}'")
+
+        return actual_dbname
+
+    @staticmethod
+    def create_user_from_username_template(conn: 'psycopg.Connection', username_template: str, password: str) -> str:
+        """
+        Safely create a PostgreSQL user, handling naming conflicts.
+
+        If a user with the given username already exists, this function will append
+        a numeric suffix (_1, _2, etc.) to create a unique username.
+
+        Args:
+            conn: PostgreSQL connection object
+            username_template: Desired username template
+            password: Password for the user
+
+        Returns:
+            str: The actual username that was created (may differ from desired if conflicts exist)
+
+        Raises:
+            RuntimeError: If unable to find a unique username after MAX_NAMING_ATTEMPTS tries
+        """
+        actual_username = username_template
+        counter = 1
+
+        for _ in range(PostgreSqlProfileCommands.MAX_NAMING_ATTEMPTS):
+            # Check if user exists
+            user_exists = PostgreSqlProfileCommands.user_exists(conn, actual_username)
+            if user_exists:
+                actual_username = f"{username_template}_{counter}"
+                counter += 1
+            else:
+                break
+        else:
+            raise RuntimeError(
+                f"Could not find a unique username after {PostgreSqlProfileCommands.MAX_NAMING_ATTEMPTS} attempts. "
+                f"Last tried: {actual_username}"
+            )
+
+        PostgreSqlProfileCommands.create_user(conn, actual_username, password)
+        logger.info(f"Created PostgreSQL user '{actual_username}'")
+
+        return actual_username
+
+    @staticmethod
+    def drop_db(conn: 'psycopg.Connection', database_name: str) -> None:
+        """Drop a PostgreSQL database.
+
+        This method will terminate all active connections to the database before dropping it.
+
+        Note: DROP DATABASE cannot run inside a transaction, so the connection
+        should be in autocommit mode.
+
+        :param conn: PostgreSQL connection object (should be in autocommit mode)
+        :param database_name: Name of the database to drop
+        """
+        with conn.cursor() as cursor:
+            # Terminate existing connections to the database
+            cursor.execute(
+                psycopg.sql.SQL("""
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = {}
+                    AND pid <> pg_backend_pid()
+                """).format(psycopg.sql.Literal(database_name))
+            )
+            # Drop the database
+            cursor.execute(
+                psycopg.sql.SQL("DROP DATABASE IF EXISTS {}").format(
+                    psycopg.sql.Identifier(database_name)
+                )
+            )
+
+    @staticmethod
+    def drop_user(conn: 'psycopg.Connection', username: str) -> None:
+        """Drop a PostgreSQL user.
+
+        :param conn: PostgreSQL connection object
+        :param username: Name of the user to drop
+        """
+        with conn.cursor() as cursor:
+            cursor.execute(
+                psycopg.sql.SQL("DROP USER IF EXISTS {}").format(
+                    psycopg.sql.Identifier(username)
+                )
+            )

--- a/src/airflow_provider_aiida/aiida_core/manage/configuration/config.py
+++ b/src/airflow_provider_aiida/aiida_core/manage/configuration/config.py
@@ -1,0 +1,536 @@
+from aiida.common.exceptions import EntryPointError, StorageMigrationError
+from typing import Any
+import logging
+import secrets
+import os
+import psycopg
+from pathlib import Path
+from airflow_provider_aiida.aiida_core.manage.configuration._postgres_utils import PostgreSqlProfileCommands
+from aiida.manage import Profile
+
+logger = logging.getLogger(__name__)
+
+# TODO as soon as this is in some formal schema of the storage_config, we do not need this
+def verify_profile_supports_airflow(profile: Profile):
+    """
+    Verify that an AiiDA profile has the necessary Airflow configuration.
+    """
+    required_keys = [
+        'airflow_database_username',
+        'airflow_database_password',
+        'airflow_database_name'
+    ]
+
+    storage_config = profile.storage_config
+    missing_keys = [key for key in required_keys if key not in storage_config]
+
+    if missing_keys:
+        raise ValueError(
+            f"Profile '{profile.name}' does not support Airflow. "
+            f"Missing required configuration keys: {', '.join(missing_keys)}.\n"
+            f"The profile must be created using the setup_aiida_profile() function "
+            f"or manually configured with Airflow database settings."
+        )
+
+def get_airflow_home(profile: Profile) -> Path:
+    from aiida.manage.configuration import get_config
+    verify_profile_supports_airflow(profile)
+
+    # Get Airflow home directory path
+    config = get_config()
+    aiida_config_dir = Path(config.dirpath)
+    return aiida_config_dir / "airflow" / profile.name
+
+def create_profile(
+    self,
+    name: str,
+    storage_backend: str,
+    storage_config: dict[str, Any],
+    broker_backend: str | None = None,
+    broker_config: dict[str, Any] | None = None,
+    is_test_profile: bool = False,
+) -> Profile:
+    """Create a new profile and initialise its storage.
+
+    NOTE: This is a copy from the function aiida.manage.configuration.config.Config::create_profile.
+          Only one line has been changed to not remove the airflow configuration.
+
+    :param name: The profile name.
+    :param storage_backend: The entry point to the :class:`aiida.orm.implementation.storage_backend.StorageBackend`
+        implementation to use for the storage.
+    :param storage_config: The configuration necessary to initialise and connect to the storage backend.
+    :param broker_backend: The entry point to the :class:`aiida.brokers.Broker` implementation to use for the
+        message broker.
+    :param broker_config: The configuration necessary to initialise and connect to the broker.
+    :returns: The created profile.
+    :raises ValueError: If the profile already exists.
+    :raises TypeError: If the ``storage_backend`` is not a subclass of
+        :class:`aiida.orm.implementation.storage_backend.StorageBackend`.
+    :raises EntryPointError: If the ``storage_backend`` does not have an associated entry point.
+    :raises StorageMigrationError: If the storage cannot be initialised.
+    """
+    from aiida.brokers import Broker
+    from aiida.orm.implementation.storage_backend import StorageBackend
+    from aiida.plugins.entry_point import load_entry_point
+
+    if name in self.profile_names:
+        raise ValueError(f'The profile `{name}` already exists.')
+
+    try:
+        storage_cls = load_entry_point('aiida.storage', storage_backend)
+    except EntryPointError as exception:
+        raise ValueError(f'The entry point `{storage_backend}` could not be loaded.') from exception
+    else:
+        if not issubclass(storage_cls, StorageBackend):
+            raise TypeError(
+                f'The `storage_backend={storage_backend}` is not a subclass of '
+                '`aiida.orm.implementation.storage_backend.StorageBackend`.'
+            )
+
+    # NOTE: Only the line below has been commented out, to not remove airlfow settings
+    #storage_config = storage_cls.Model(**(storage_config or {})).model_dump()
+
+    if broker_backend is not None:
+        try:
+            broker_cls = load_entry_point('aiida.brokers', broker_backend)
+        except EntryPointError as exception:
+            raise ValueError(f'The entry point `{broker_backend}` could not be loaded.') from exception
+        else:
+            if not issubclass(broker_cls, Broker):
+                raise TypeError(
+                    f'The `broker_backend={broker_backend}` is not a subclass of `aiida.brokers.broker.Broker`.'
+                )
+
+    profile = Profile(
+        name,
+        {
+            'storage': {
+                'backend': storage_backend,
+                'config': storage_config,
+            },
+            'process_control': {
+                'backend': broker_backend,
+                'config': broker_config,
+            },
+            'test_profile': is_test_profile,
+        },
+    )
+
+    logger.info('Initialising the storage backend.')
+    try:
+        profile.storage_cls.initialise(profile)
+    except Exception as exception:
+        raise StorageMigrationError(
+            f'Storage backend initialisation failed, probably because the configuration is incorrect:\n{exception}'
+        )
+    logger.info('Storage initialisation completed.')
+
+    self.add_profile(profile)
+    self.store()
+
+    return profile
+
+
+def create_psql_database_from_aiida_profile(
+    profile_name: str,
+    postgres_hostname: str,
+    postgres_port: int,
+    postgres_admin_username: str,
+    postgres_admin_password: str,
+) -> dict[str, Any]:
+    """
+    Creates AiiDA and Airflow databases with a shared database user.
+
+    This function:
+    1. Creates a single PostgreSQL user (handling naming conflicts with suffixes)
+    2. Creates the AiiDA database owned by this user
+    3. Creates the Airflow database owned by the same user
+
+    Both databases share the same user for simplicity and efficiency.
+
+    Args:
+        profile_name: The AiiDA profile name to use as the base
+        postgres_hostname: PostgreSQL server hostname
+        postgres_port: PostgreSQL server port
+        postgres_admin_username: PostgreSQL admin username (must have CREATEDB and CREATEROLE privileges)
+        postgres_admin_password: PostgreSQL admin password
+
+    Returns:
+        Dictionary containing database configuration for both AiiDA and Airflow:
+        - database_*: AiiDA database configuration
+        - airflow_database_*: Airflow database configuration
+        Both configurations share the same username and password.
+
+    Raises:
+        ConnectionError: If unable to connect to PostgreSQL or create database/user
+    """
+    from aiida.manage.configuration.settings import AiiDAConfigDir
+
+    # Connect to PostgreSQL using admin credentials
+    psql_config = {
+        'host': postgres_hostname,
+        'port': postgres_port,
+        'user': postgres_admin_username,
+        'password': postgres_admin_password,
+    }
+
+    with psycopg.connect(**psql_config) as conn:
+        # Set autocommit mode because CREATE DATABASE cannot run inside a transaction
+        conn.autocommit = True
+
+        # Create database user first (shared between AiiDA and Airflow)
+        desired_username = f'aiida-{profile_name}'
+        aiida_database_password = secrets.token_hex(15)
+        aiida_database_username = PostgreSqlProfileCommands.create_user_from_username_template(conn, desired_username, aiida_database_password)
+
+
+        if aiida_database_username != desired_username:
+            logger.info(
+                f"Database user '{desired_username}' already exists. "
+                f"Created new user '{aiida_database_username}' instead."
+            )
+
+        # Create AiiDA database (using the shared user)
+        desired_database_name = f'aiida-{profile_name}' 
+        aiida_database_name = PostgreSqlProfileCommands.create_db_from_dbname_template(
+            conn,
+            desired_database_name,
+            aiida_database_username,
+        )
+
+        if desired_database_name != aiida_database_name:
+            logger.info(
+                f"Database user '{desired_database_name}' already exists. "
+                f"Created new user '{aiida_database_name}' instead."
+            )
+        
+        # Create database user first (shared between airflow and Airflow)
+        desired_username = f'airflow-{profile_name}'
+        airflow_database_password = secrets.token_hex(15)
+        airflow_database_username = PostgreSqlProfileCommands.create_user_from_username_template(conn, desired_username, airflow_database_password)
+
+        if airflow_database_username != desired_username:
+            logger.info(
+                f"Database user '{desired_username}' already exists. "
+                f"Created new user '{airflow_database_username}' instead."
+            )
+
+        # Create airflow database (using the shared user)
+        desired_database_name = f'airflow-{profile_name}' 
+        airflow_database_name = PostgreSqlProfileCommands.create_db_from_dbname_template(
+            conn,
+            desired_database_name,
+            airflow_database_username,
+        )
+
+        if desired_database_name != airflow_database_name:
+            logger.info(
+                f"Database user '{desired_database_name}' already exists. "
+                f"Created new user '{airflow_database_name}' instead."
+            )
+
+    aiida_config_folder = AiiDAConfigDir.get()
+    return {'database_engine': 'postgresql_psycopg',
+            'database_hostname': postgres_hostname,
+            'database_port': postgres_port,
+            'database_username': aiida_database_username,
+            'database_password': aiida_database_password,
+            'database_name': aiida_database_name,
+            'repository_uri': Path(f'{aiida_config_folder / "repository" / profile_name}').as_uri(),
+            'airflow_database_engine': 'postgresql_psycopg',
+            'airflow_database_username': airflow_database_username,
+            'airflow_database_password': airflow_database_password,
+            'airflow_database_name': airflow_database_name,
+        }
+
+
+def delete_aiida_profile(profile_name: str, pg_admin_user: str, pg_admin_password: str):
+    """
+    Delete an AiiDA profile with Airflow support.
+
+    Args:
+        profile_name: Name of the profile to delete.
+        pg_admin_user: PostgreSQL admin user (needed to drop databases and users).
+                      If None, uses POSTGRES_USER env var or 'postgres'.
+        pg_admin_password: PostgreSQL admin password.
+                          If None, uses POSTGRES_PASSWORD env var or 'postgres'.
+    """
+    from aiida.manage.configuration import get_config
+    from aiida import load_profile
+
+    profile = load_profile(profile_name)
+    assert profile.storage_config['database_engine'] == "postgresql_psycopg", "We only support PostgreSQL for the moment"
+
+    verify_profile_supports_airflow(profile)
+    delete_psql_database_from_aiida_profile(profile, pg_admin_user, pg_admin_password)
+    get_config().delete_profile(profile.name, delete_storage=False)
+
+
+def delete_psql_database_from_aiida_profile(profile: Profile, pg_admin_user: str, pg_admin_password: str):
+    """
+    Remove both AiiDA and Airflow databases and their associated users for a given profile.
+
+    Uses admin credentials to connect to PostgreSQL and drop databases and users.
+
+    Args:
+        profile: AiiDA profile containing database configuration
+        pg_admin_user: PostgreSQL admin user (needed to drop databases and users)
+        pg_admin_password: PostgreSQL admin password
+    """
+    # Verify that the profile has Airflow support
+    verify_profile_supports_airflow(profile)
+
+    # Extract database information from profile storage config
+    storage_config = profile.storage_config
+
+    # AiiDA database configuration
+    aiida_database_host = storage_config['database_hostname']
+    aiida_database_port = storage_config['database_port']
+    aiida_db_name = storage_config['database_name']
+    aiida_db_username = storage_config['database_username']
+
+    # Airflow database configuration
+    airflow_db_name = storage_config['airflow_database_name']
+    airflow_db_username = storage_config['airflow_database_username']
+
+    logger.info(f"Removing databases and users for profile '{profile.name}'")
+    logger.info(f"  Host: {aiida_database_host}:{aiida_database_port}")
+    logger.info(f"  AiiDA database: {aiida_db_name}")
+    logger.info(f"  Airflow database: {airflow_db_name}")
+    logger.info(f"  Database users: {aiida_db_username}, {airflow_db_username}")
+
+    # Connect to PostgreSQL using admin credentials
+    # We use admin credentials because users cannot drop themselves
+    psql_config = {
+        'host': aiida_database_host,
+        'port': aiida_database_port,
+        'user': pg_admin_user,
+        'password': pg_admin_password,
+        'dbname': 'postgres'
+    }
+
+    with psycopg.connect(**psql_config) as conn:
+        # Set autocommit mode because DROP DATABASE cannot run inside a transaction
+        conn.autocommit = True
+
+        # Drop AiiDA database
+        logger.info(f"Dropping AiiDA database '{aiida_db_name}'")
+        PostgreSqlProfileCommands.drop_db(conn, aiida_db_name)
+        logger.info(f"Successfully dropped AiiDA database '{aiida_db_name}'")
+
+        # Drop Airflow database
+        logger.info(f"Dropping Airflow database '{airflow_db_name}'")
+        PostgreSqlProfileCommands.drop_db(conn, airflow_db_name)
+        logger.info(f"Successfully dropped Airflow database '{airflow_db_name}'")
+
+        # Drop users (remove duplicates in case both databases share the same user)
+        users_to_drop = list(set([aiida_db_username, airflow_db_username]))
+        for username in users_to_drop:
+            logger.info(f"Dropping database user '{username}'")
+            PostgreSqlProfileCommands.drop_user(conn, username)
+            logger.info(f"Successfully dropped database user '{username}'")
+
+    logger.info(f"Successfully removed all databases and users for profile '{profile.name}'")
+
+def create_aiida_profile(pg_host: str, pg_port: int, pg_admin_user: str, pg_admin_password: str, profile_name: str, overwrite: bool = True):
+    """
+    Set up Airflow database using the AiiDA profile's PostgreSQL server.
+
+    Args:
+        pg_host: PostgreSQL hostname (root credentials)
+        pg_port: PostgreSQL port
+        pg_admin_user: PostgreSQL admin user (used to create airflow database)
+        pg_admin_password: PostgreSQL admin password
+        profile_name: Profile name (used to name airflow database)
+        overwrite: TODO
+    """
+    from aiida.manage.configuration import get_config
+    from aiida.manage.configuration import create_default_user
+
+    logger.info("Setting up AiiDA profile with Airflow support")
+    logger.info(f"Profile name: {profile_name}")
+    logger.info(f"PostgreSQL configuration:")
+    logger.info(f"  Host: {pg_host}")
+    logger.info(f"  Port: {pg_port}")
+    logger.info(f"  Admin user: {pg_admin_user}")
+
+    pg_database = f"aiida-{profile_name}"
+
+    # Get AiiDA configuration (create if it doesn't exist)
+    config = get_config(create=True)
+
+    # Check if profile already exists
+    if profile_name in config.profile_names:
+        logger.info(f"Profile '{profile_name}' already exists")
+
+        from airflow_provider_aiida.aiida_core import load_profile
+        profile = load_profile(profile_name)
+        if overwrite:
+            logger.info(f"Deleting existing profile '{profile_name}'")
+            delete_psql_database_from_aiida_profile(profile, pg_admin_user, pg_admin_password)
+            config.remove_profile(profile_name)
+            config.store()
+            logger.info(f"Successfully deleted existing profile '{profile_name}'")
+        else:
+            logger.info(f"Using existing profile '{profile_name}'")
+            return profile
+
+    # Create profile configuration
+    logger.info(f"Creating AiiDA and Airflow databases for profile '{profile_name}'")
+    db_config = create_psql_database_from_aiida_profile(
+        profile_name,
+        pg_host,
+        pg_port,
+        pg_admin_user,
+        pg_admin_password,
+    )
+    logger.info(f"Successfully created databases for profile '{profile_name}'")
+
+    logger.info(f"Creating AiiDA profile '{profile_name}'")
+    # creates profile in config and initializes database
+    profile = create_profile(
+        config,
+        name=profile_name,
+        storage_backend='core.psql_dos',
+        storage_config=db_config,
+        is_test_profile = True,
+    )
+
+    # Set as default profile and creates aiida user in database
+    create_default_user(profile, f'{profile_name}@aiida.net')
+    logger.info(f"Successfully created AiiDA profile '{profile_name}'")
+    config.set_default_profile(profile.name, overwrite=True)
+    config.store()
+    logger.info(f"Set profile '{profile_name}' as default")
+
+    # Initialize storage by loading the profile
+    # This is necessary to create the database tables and initialize the storage backend
+    logger.info("Initializing storage (creating database tables)")
+    from airflow_provider_aiida.aiida_core import load_profile
+    profile = load_profile(profile_name)
+    logger.info("Successfully initialized storage and created database tables")
+
+    # Show summary
+    logger.info(f"Profile setup summary:")
+    logger.info(f"  Profile name: {profile_name}")
+    logger.info(f"  Database: {pg_host}:{pg_port}/{pg_database}")
+    logger.info(f"  Storage backend: {profile.storage_backend}")
+    logger.info(f"  Config directory: {config.dirpath}")
+    logger.info(f"  Airflow home: {os.environ.get('AIRFLOW_HOME')}")
+
+    import subprocess
+    from aiida.manage.configuration import get_config
+
+    logger.info("Initializing Airflow database schema")
+
+    # Set up Airflow home directory in AiiDA config
+    from_profile_create_airflow_config(profile)
+    # Initialize Airflow database
+    try:
+        logger.info("Running Airflow database migrations")
+        subprocess.run(
+            ["airflow", "db", "migrate"],
+            env=None,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        logger.info("Successfully initialized Airflow database")
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to initialize Airflow database: {e}")
+        logger.error(f"stdout: {e.stdout}")
+        logger.error(f"stderr: {e.stderr}")
+        raise
+
+    try:
+        logger.info("Running Airflow DAG serialization")
+        subprocess.run(
+            ["airflow", "dags", "reserialize", "--bundle-name", "aiida_dags"],
+            env=None,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        logger.info("Successfully serialized DAGs")
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to serialized DAGs: {e}")
+        logger.error(f"stdout: {e.stdout}")
+        logger.error(f"stderr: {e.stderr}")
+        raise
+
+    logger.info(f"Successfully completed setup for profile '{profile_name}'")
+
+
+def from_profile_create_airflow_config(profile: Profile):
+    """
+    Create Airflow environment variables from an AiiDA profile.
+
+    Args:
+        profile: The AiiDA profile containing Airflow configuration
+
+    Returns:
+        Dictionary of environment variables for Airflow
+    """
+    from aiida.manage.configuration import get_config
+    verify_profile_supports_airflow(profile)
+
+    # Get Airflow home directory path
+    config = get_config()
+
+    # Extract Airflow database configuration from profile storage config
+    storage_config = profile.storage_config
+
+    airflow_db_user = storage_config["airflow_database_username"]
+    airflow_db_password = storage_config["airflow_database_password"]
+    airflow_db_host = storage_config["database_hostname"]
+    airflow_db_port = storage_config["database_port"]
+    airflow_db_name = storage_config["airflow_database_name"]
+
+    # Build Airflow database connection string
+    db_conn = f"postgresql+psycopg2://{airflow_db_user}:{airflow_db_password}@{airflow_db_host}:{airflow_db_port}/{airflow_db_name}"
+
+    dag_bundle = '[{"name":"aiida_dags","classpath":"airflow_provider_aiida.bundles.aiida_dag_bundle.AiidaDagBundle","kwargs":{}}]'
+
+    airflow_home = get_airflow_home(profile)
+    airflow_home.mkdir(parents=True, exist_ok=True)
+
+
+    from airflow.configuration import AirflowConfigParser
+    from base64 import b64encode
+    num_workers = config.get_option("daemon.default_workers")
+
+    airflow_config = AirflowConfigParser()
+    airflow_config_file = airflow_home / 'airflow.cfg'
+
+    # Read existing config if it exists to preserve secret keys
+    if airflow_config_file.exists():
+        airflow_config.read(airflow_config_file)
+
+    # Generate secret keys for JWT authentication ONLY if they don't already exist
+    # These keys must be the same across all Airflow services (scheduler, triggerer, api-server)
+    fernet_key = b64encode(secrets.token_bytes(32)).decode('utf-8')
+    jwt_secret = b64encode(secrets.token_bytes(16)).decode('utf-8')
+    api_secret = b64encode(secrets.token_bytes(16)).decode('utf-8')
+
+    airflow_config.set('core', 'parallelism', str(num_workers))
+    airflow_config.set('core', 'dags_are_paused_at_creation', 'False')
+    airflow_config.set('core', 'max_active_tasks_per_dag', '1000000')
+    airflow_config.set('core', 'max_active_runs_per_dag', '1000000')
+    airflow_config.set('core', 'default_timezone', 'system')
+    airflow_config.set('core', 'load_examples', 'False')
+    airflow_config.set('core', 'fernet_key', fernet_key)
+    airflow_config.set('database', 'sql_alchemy_conn', db_conn)
+    airflow_config.set('dag_processor', 'dag_bundle_config_list', dag_bundle)
+    airflow_config.set('api_auth', 'jwt_secret', jwt_secret)
+    airflow_config.set('api', 'secret_key', api_secret)
+
+    with open(airflow_config_file, 'w') as f:
+        # Write with all documentation and comments
+        airflow_config.write(
+            f,
+            include_descriptions=True,
+            include_examples=True,
+            include_env_vars=True,
+            comment_out_everything=False,
+            extra_spacing=True
+        )

--- a/src/airflow_provider_aiida/bundles/aiida_dag_bundle.py
+++ b/src/airflow_provider_aiida/bundles/aiida_dag_bundle.py
@@ -73,10 +73,9 @@ class AiidaDagBundle(LocalDagBundle):
             # Get the package path
             if hasattr(module, '__path__'):
                 # It's a package, use its directory
-                path = Path(module.__file__).parent
+                path = module.__path__[0]
             else:
-                # It's a single module, use its parent directory
-                path = Path(module.__file__).parent
+                raise ValueError("Pleas contact developer.")
 
             log.info(f"Using DAG path: {path}")
             return str(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,45 @@
 import pytest
-from aiida import load_profile
-
-load_profile()
+import os
 
 
 @pytest.fixture(scope='session')
-def bash_code():
+def aiida_profile():
+    """Load and return the AiiDA profile for testing.
+
+    The profile name is read from the AIIDA_PROFILE environment variable.
+    This fixture is session-scoped, so the profile is loaded once per test session.
+
+    Returns:
+        Profile: The loaded AiiDA profile
+
+    Raises:
+        RuntimeError: If AIIDA_PROFILE is not set or profile cannot be loaded
+    """
+    from airflow_provider_aiida.aiida_core import load_profile
+
+    profile_name = os.getenv('AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE')
+
+    if profile_name is None:
+        raise RuntimeError(
+            "AIRFLOW_PROVIDER_AIIDA__TESTS__AIIDA_PROFILE environment variable is not set.\n"
+            "This should be set automatically by the hatch-test environment.\n"
+            "If running tests manually, set it with: export AIIDA_PROFILE=test"
+        )
+
+    try:
+        profile = load_profile(profile_name)
+    except Exception as e:
+        print(f"\n✗ Failed to load AiiDA profile '{profile_name}'")
+        print(f"Error: {e}")
+        print("\nPlease create the test profile first:")
+        print("  hatch run hatch-test.py3.11:setup-profile")
+        raise
+
+    return profile
+
+
+@pytest.fixture(scope='session')
+def bash_code(aiida_profile):
     """Create and return the bash@localhost code for tests.
 
     This fixture automatically sets up:


### PR DESCRIPTION
Support for Airflow in AiiDA profile
    
  Introduces profile creation in utils/profile.py to store
  information about the Airflow configuration in the AiiDA profile.
  
  In addition scripts have been created that expose the profile management
  functions in form of a CLI that will be later merged into the AiiDA CLI.
  Only PostgreSQL is for now supported.
  
  The test profile is created using these utilities to allow easier
  debugging by having direct access to the test profile.
  
  Key features:
  - Profile creation with integrated Airflow database setup
  - Automatic extraction of Airflow environment from profile configuration
  - Profile verification to ensure Airflow support
  - Proper teardown of both AiiDA and Airflow databases/users
  
  Implementation details:
  
  1. Profile Management (utils/profile.py):
     - create_aiida_profile(): Creates AiiDA profile with Airflow support
     - delete_aiida_profile(): Removes profile and cleans up databases/users
     - create_psql_database_from_aiida_profile(): Creates separate AiiDA and Airflow databases
     - delete_psql_database_from_aiida_profile(): Drops databases and users using admin credentials
     - verify_profile_supports_airflow(): Validates required Airflow configuration keys
     - from_profile_create_airflow_env(): Extracts Airflow environment variables from profile
     - Uses admin credentials in delete also to also delete the psql database
  
  2. CLI Scripts:
     - scripts/cmd_profile_create.py: Creates new AiiDA profiles with Airflow support
     - scripts/cmd_profile_delete.py: Deletes profiles with verification and cleanup
     - scripts/cmd_airflow.py: Executes Airflow CLI commands with profile environment
       (uses direct argument pass-through to support Airflow flags like -B)
  
  Technical notes:
  - Separate for AiiDA and Airflow, potentially same
  - Admin credentials required for database/user deletion (PostgreSQL restriction)
  - Profile verification ensures Airflow configuration is present before operations
  - AIRFLOW_HOME stored in profile's config directory: <aiida_config>/<aiida_profile>/airflow